### PR TITLE
Bind the application in fedora_mock to container IP address

### DIFF
--- a/test_sources/images/fedora-mock/mock_server.rb
+++ b/test_sources/images/fedora-mock/mock_server.rb
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
 require 'webrick'
-require 'webrick/https'
 include WEBrick
 
 config = {}
-cert_name = [["CN",`hostname`.strip]]
 config.update(:Port => 8080)
 config.update(:BindAddress => ARGV[0])
 config.update(:DocumentRoot => ARGV[1])

--- a/test_sources/images/fedora-mock/run
+++ b/test_sources/images/fedora-mock/run
@@ -1,3 +1,6 @@
-#!/bin/bash -x
+#!/bin/bash
 
-exec /usr/mock/mock_server.rb 0.0.0.0 /usr/mock/source/
+CONTAINER_IP_ADDR=$(ip a s | sed -ne '/127.0.0.1/!{s/^[ \t]*inet[ \t]*\([0-9.]\+\)\/.*$/\1/p}')
+
+set -x
+exec /usr/mock/mock_server.rb ${CONTAINER_IP_ADDR} /usr/mock/source/


### PR DESCRIPTION
- removed SSL stuff from mock_server, which is not used anywhere ;-)
