### PR TITLE
Add parameter to STI build to invoke an optional callback url

### DIFF
--- a/go/sti/sti.go
+++ b/go/sti/sti.go
@@ -103,6 +103,8 @@ func Execute() {
 	buildCmd.Flags().StringVarP(&envString, "env", "e", "", "Specify an environment var NAME=VALUE,NAME2=VALUE2,...")
 	buildCmd.Flags().StringVarP(&(buildReq.Method), "method", "m", "run", "Specify a method to build with. build -> 'docker build', run -> 'docker run'")
 	buildCmd.Flags().StringVarP(&(buildReq.Ref), "ref", "r", "", "Specify a ref to check-out")
+	buildCmd.Flags().StringVar(&(buildReq.CallbackUrl), "callbackUrl", "", "Specify a URL to invoke via HTTP POST upon build completion")
+
 	stiCmd.AddCommand(buildCmd)
 
 	validateCmd := &cobra.Command{


### PR DESCRIPTION
This will be used by gear build to support callback to broker for long-running operation.
