### PR TITLE
Allow non-root USER

### DIFF
--- a/dockerfiles/sti-fake-user/Dockerfile
+++ b/dockerfiles/sti-fake-user/Dockerfile
@@ -1,0 +1,8 @@
+FROM pmorie/sti-fake
+
+RUN mkdir -p /sti-fake && \
+    groupadd -r fakeuser -f -g 433 && \
+    useradd -u 431 -r -g fakeuser -d /sti-fake -s /sbin/nologin -c "Fake User" fakeuser && \
+    chown -R fakeuser:fakeuser /sti-fake
+
+USER fakeuser

--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -32,6 +32,7 @@ const (
 	TestSource   = "git://github.com/pmorie/simple-html"
 
 	FakeBaseImage       = "pmorie/sti-fake"
+	FakeUserImage       = "pmorie/sti-fake-user"
 	FakeBuildImage      = "pmorie/sti-fake-builder"
 	FakeBrokenBaseImage = "pmorie/sti-fake-broken"
 
@@ -39,6 +40,7 @@ const (
 	TagIncrementalBuild = "test/sti-incremental-app"
 
 	TagCleanBuildRun       = "test/sti-fake-app-run"
+	TagCleanBuildRunUser   = "test/sti-fake-app-run-user"
 	TagIncrementalBuildRun = "test/sti-incremental-app-run"
 )
 
@@ -95,20 +97,24 @@ func (s *IntegrationTestSuite) TestValidateFailure(c *C) {
 
 // Test a clean build.  The simplest case.
 func (s *IntegrationTestSuite) TestCleanBuild(c *C) {
-	s.exerciseCleanBuild(c, TagCleanBuild, false)
+	s.exerciseCleanBuild(c, TagCleanBuild, false, FakeBaseImage)
 }
 
 func (s *IntegrationTestSuite) TestCleanBuildRun(c *C) {
-	s.exerciseCleanBuild(c, TagCleanBuildRun, true)
+	s.exerciseCleanBuild(c, TagCleanBuildRun, true, FakeBaseImage)
 }
 
-func (s *IntegrationTestSuite) exerciseCleanBuild(c *C, tag string, useRun bool) {
+func (s *IntegrationTestSuite) TestCleanBuildRunUser(c *C) {
+	s.exerciseCleanBuild(c, TagCleanBuildRunUser, true, FakeUserImage)
+}
+
+func (s *IntegrationTestSuite) exerciseCleanBuild(c *C, tag string, useRun bool, imageName string) {
 	req := BuildRequest{
 		Request: Request{
 			WorkingDir:   s.tempDir,
 			DockerSocket: DockerSocket,
 			Verbose:      true,
-			BaseImage:    FakeBaseImage},
+			BaseImage:    imageName},
 		Source: TestSource,
 		Tag:    tag,
 		Clean:  true,


### PR DESCRIPTION
Add sti-fake-user Dockerfile which extends sti-fake and runs as a
non-root user.

Add integration test to ensure that non-root images work ok.

Fix issues with support for non-root users:
- set config.User prior to committing if the base image has a USER
- workaround issue in Docker where you can't run a container from an
  image whose original container had a file bind mount, and you don't
  specify something to satisfy that file bind mount when running.
