### PR TITLE
Switch to multi-platform release build

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -12,10 +12,7 @@ hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 . "${hackdir}/config-go.sh"
 
 # Go to the top of the tree.
-cd "${OS_REPO_ROOT}"
-
-# Fetch the version.
-version=$(gitcommit)
+cd "${STI_REPO_ROOT}"
 
 if [[ $# == 0 ]]; then
   # Update $@ with the default list of targets to build.
@@ -24,12 +21,12 @@ fi
 
 binaries=()
 for arg; do
-  binaries+=("${OS_GO_PACKAGE}/${arg}")
+  binaries+=("${STI_GO_PACKAGE}/${arg}")
 done
 
 build_tags=""
-if [[ ! -z "$OS_BUILD_TAGS" ]]; then
-  build_tags="-tags \"$OS_BUILD_TAGS\""
+if [[ ! -z "$STI_BUILD_TAGS" ]]; then
+  build_tags="-tags \"$STI_BUILD_TAGS\""
 fi
 
-go install $build_tags -ldflags "-X github.com/openshift/source-to-image/pkg/sti/version.commitFromGit '${version}'" "${binaries[@]}"
+go install $build_tags -ldflags "$(sti::build::ldflags)" "${binaries[@]}"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -12,7 +12,7 @@ hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 . "${hackdir}/config-go.sh"
 
 # Go to the top of the tree.
-cd "${OS_REPO_ROOT}"
+cd "${STI_REPO_ROOT}"
 
 docker build -t sti_test/sti-fake test/integration/images/sti-fake
 docker build -t sti_test/sti-fake-broken test/integration/images/sti-fake-broken 

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script generates a release script in _output/releases
+# This script generates release zips into _output/releases
 
 set -o errexit
 set -o nounset
@@ -8,30 +8,30 @@ set -o pipefail
 
 hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 
-
 # Set the environment variables required by the build.
 . "${hackdir}/config-go.sh"
 
 # Go to the top of the tree.
-cd "${OS_REPO_ROOT}"
+cd "${STI_REPO_ROOT}"
 
-# Build clean
-make clean
-hack/build-go.sh
+context="${STI_REPO_ROOT}/_output/buildenv-context"
 
-# Fetch the version.
-version=$(gitcommit)
+# clean existing output
+rm -rf "${STI_REPO_ROOT}/_output/releases"
+rm -rf "${context}"
+mkdir -p "${context}"
 
-# Copy built contents to the release directory
-release="_output/release"
-rm -rf "${release}"
-mkdir -p "${release}"
-cp _output/go/bin/sti "${release}"
+# generate version definitions
+echo "export STI_VERSION=0.1"                            > "${context}/sti-version-defs"
+echo "export STI_GITCOMMIT=\"$(sti::build::gitcommit)\"" >> "${context}/sti-version-defs"
+echo "export STI_LD_FLAGS=\"$(sti::build::ldflags)\""    >> "${context}/sti-version-defs"
 
-releases="_output/releases"
-mkdir -p "${releases}"
-release_file="${releases}/openshift-sti-linux64-${version}.tar.gz"
+# create the input archive
+git archive --format=tar -o "${context}/archive.tar" HEAD
+tar -rf "${context}/archive.tar" -C "${context}" sti-version-defs
+gzip -f "${context}/archive.tar"
 
-tar cvzf "${release_file}" -C "${release}" .
-
-echo "Built to ${release_file}"
+# build in the clean environment
+docker build --tag openshift-sti-buildenv "${STI_REPO_ROOT}/hack/buildenv"
+cat "${context}/archive.tar.gz" | docker run -i --cidfile="${context}/cid" openshift-sti-buildenv
+docker cp $(cat ${context}/cid):/go/src/github.com/openshift/source-to-image/_output/releases "${STI_REPO_ROOT}/_output"

--- a/hack/buildenv/Dockerfile
+++ b/hack/buildenv/Dockerfile
@@ -1,0 +1,25 @@
+# This file creates a standard build environment for building STI
+FROM  fedora:21
+
+RUN yum install -y git hg golang golang-pkg-darwin golang-pkg-windows && yum clean all
+
+ENV GOPATH /go
+# Get the code coverage tool and godep
+RUN go get code.google.com/p/go.tools/cmd/cover github.com/tools/godep
+
+# Mark this as a sti-build container
+RUN touch /sti-build-image
+
+WORKDIR /go/src/github.com/openshift/source-to-image
+
+ENV OS_CROSSPLATFORMS \
+  darwin/amd64 \
+  windows/amd64
+# (set an explicit GOARM of 5 for maximum compatibility)
+ENV GOARM 5
+ENV GOOS    linux
+ENV GOARCH  amd64
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
+# Expect a tar with the source of STI (and /os-version-defs in the root)
+CMD tar -xzf - && ./hack/buildenv/build.sh

--- a/hack/buildenv/build.sh
+++ b/hack/buildenv/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/buildenv/common.sh"
+
+platforms=(linux/amd64 $OS_CROSSPLATFORMS)
+targets=("${compile_targets[@]}")
+
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+fi
+
+for platform in "${platforms[@]}"; do
+  (
+    # Subshell to contain these exports
+    export GOOS=${platform%/*}
+    export GOARCH=${platform##*/}
+
+    os::build::make_binaries "${targets[@]}"
+  )
+done

--- a/hack/buildenv/common.sh
+++ b/hack/buildenv/common.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+STI_ROOT=$(dirname "${BASH_SOURCE}")/../..
+cd "${STI_ROOT}"
+
+source "${STI_ROOT}/hack/common.sh"
+
+readonly STI_TARGET="${STI_ROOT}/_output/build"
+readonly STI_GO_PACKAGE=github.com/openshift/source-to-image
+readonly STI_RELEASES="${STI_ROOT}/_output/releases"
+
+compile_targets=(
+  cmd/sti
+)
+
+mkdir -p "${STI_TARGET}"
+
+if [[ ! -f "/sti-build-image" ]]; then
+  echo "WARNING: This script should be run in the os-build container image!" >&2
+fi
+
+if [[ -f "./sti-version-defs" ]]; then
+  source "./sti-version-defs"
+else
+  echo "WARNING: No version information provided in build image"
+  readonly STI_VERSION="${STI_VERSION:-unknown}"
+  readonly STI_GITCOMMIT="${STI_GITCOMMIT:-unknown}"
+fi
+
+
+function os::build::make_binary() {
+  local -r gopkg=$1
+  local -r bin=${gopkg##*/}
+
+  echo "+++ Building ${bin} for ${GOOS}/${GOARCH}"
+  pushd "${STI_ROOT}" >/dev/null
+  godep go build -ldflags "${STI_LD_FLAGS-}" -o "${ARCH_TARGET}/${bin}" "${gopkg}"
+  popd >/dev/null
+}
+
+function os::build::make_binaries() {
+  [[ $# -gt 0 ]] || {
+    echo "!!! Internal error. os::build::make_binaries called with no targets."
+  }
+
+  local -a targets=("$@")
+  local -a binaries=()
+  local target
+  for target in "${targets[@]}"; do
+    binaries+=("${STI_GO_PACKAGE}/${target}")
+  done
+
+  ARCH_TARGET="${STI_TARGET}/${GOOS}/${GOARCH}"
+  mkdir -p "${ARCH_TARGET}"
+
+  local b
+  for b in "${binaries[@]}"; do
+    os::build::make_binary "$b"
+  done
+
+  mkdir -p "${STI_RELEASES}"
+  readonly ARCHIVE_NAME="openshift-sti-${STI_VERSION}-${STI_GITCOMMIT}-${GOOS}-${GOARCH}.tar.gz"
+  tar -czf "${STI_RELEASES}/${ARCHIVE_NAME}" -C "${ARCH_TARGET}" .
+}

--- a/hack/buildenv/export.sh
+++ b/hack/buildenv/export.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+STI_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${STI_ROOT}/hack/buildenv/common.sh"
+
+tar -C "${STI_RELEASES}" -cf - .

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script provides common script functions for the hacks
+
+# sti::build::gitcommit prints the current Git commit information
+function sti::build::gitcommit() {
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  topdir=$(dirname "$0")/..
+  cd "${topdir}"
+
+  # TODO: when we start making tags, switch to git describe?
+  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
+    # Check if the tree is dirty.
+    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
+      echo "${git_commit}-dirty"
+    else
+      echo "${git_commit}"
+    fi
+  else
+    echo "(none)"
+  fi
+  return 0
+}
+
+
+# sti::build::ldflags calculates the -ldflags argument for building STI
+function sti::build::ldflags() {
+  (
+    # Run this in a subshell to prevent settings/variables from leaking.
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
+    topdir=$(dirname "$0")/..
+    cd "${topdir}"
+
+    declare -a ldflags=()
+    ldflags+=(-X "github.com/openshift/source-to-image/pkg/sti/version.commitFromGit" "$(sti::build::gitcommit)")
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+  )
+}

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -3,28 +3,8 @@
 # This script sets up a go workspace locally and builds all go components.
 # You can 'source' this file if you want to set up GOPATH in your local shell.
 
-# gitcommit prints the current Git commit information
-function gitcommit() {
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  topdir=$(dirname "$0")/..
-  cd "${topdir}"
-
-  # TODO: when we start making tags, switch to git describe?
-  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
-    # Check if the tree is dirty.
-    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
-      echo "${git_commit}-dirty"
-    else
-      echo "${git_commit}"
-    fi
-  else
-    echo "(none)"
-  fi
-  return 0
-}
+hackdir=$(CDPATH="" cd $(dirname $0); pwd)
+source "${hackdir}/common.sh"
 
 if [[ -z "$(which go)" ]]; then
   echo "Can't find 'go' in PATH, please fix and retry." >&2
@@ -39,39 +19,45 @@ if [[ "${TRAVIS:-}" != "true" ]]; then
   GO_VERSION=($(go version))
   if [[ "${GO_VERSION[2]}" < "go1.2" ]]; then
     echo "Detected go version: ${GO_VERSION[*]}." >&2
-    echo "OpenShift requires go version 1.2 or greater." >&2
+    echo "STI requires go version 1.2 or greater." >&2
     echo "Please install Go version 1.2 or later" >&2
     exit 1
   fi
 fi
 
-OS_REPO_ROOT=$(dirname "${BASH_SOURCE:-$0}")/..
-if [[ "${OSTYPE:-}" == *darwin* ]]; then
-  # Make the path absolute if it is not.
-  if [[ "${OS_REPO_ROOT}" != /* ]]; then
-    OS_REPO_ROOT=${PWD}/${OS_REPO_ROOT}
-  fi
-else
-  # Resolve symlinks.
-  OS_REPO_ROOT=$(readlink -f "${OS_REPO_ROOT}")
-fi
+STI_REPO_ROOT=$(dirname "${BASH_SOURCE:-$0}")/..
+case "$(uname)" in
+  Darwin)
+    # Make the path absolute if it is not.
+    if [[ "${STI_REPO_ROOT}" != /* ]]; then
+      STI_REPO_ROOT=${PWD}/${STI_REPO_ROOT}
+    fi
+    ;;
+  Linux)
+    # Resolve symlinks.
+    STI_REPO_ROOT=$(readlink -f "${STI_REPO_ROOT}")
+    ;;
+  *)
+    echo "Unsupported operating system: \"$(uname)\"" >&2
+    exit 1
+esac
 
-OS_TARGET="${OS_REPO_ROOT}/_output/go"
-mkdir -p "${OS_TARGET}"
+STI_TARGET="${STI_REPO_ROOT}/_output/go"
+mkdir -p "${STI_TARGET}"
 
-OS_GO_PACKAGE=github.com/openshift/source-to-image
-OS_GO_PACKAGE_DIR="${OS_TARGET}/src/${OS_GO_PACKAGE}"
+STI_GO_PACKAGE=github.com/openshift/source-to-image
+STI_GO_PACKAGE_DIR="${STI_TARGET}/src/${STI_GO_PACKAGE}"
 
-OS_GO_PACKAGE_BASEDIR=$(dirname "${OS_GO_PACKAGE_DIR}")
-mkdir -p "${OS_GO_PACKAGE_BASEDIR}"
+STI_GO_PACKAGE_BASEDIR=$(dirname "${STI_GO_PACKAGE_DIR}")
+mkdir -p "${STI_GO_PACKAGE_BASEDIR}"
 
 # Create symlink under _output/go/src.
-ln -snf "${OS_REPO_ROOT}" "${OS_GO_PACKAGE_DIR}"
+ln -snf "${STI_REPO_ROOT}" "${STI_GO_PACKAGE_DIR}"
 
-GOPATH="${OS_TARGET}:${OS_REPO_ROOT}/Godeps/_workspace"
+GOPATH="${STI_TARGET}:${STI_REPO_ROOT}/Godeps/_workspace"
 export GOPATH
 
 # Unset GOBIN in case it already exists in the current session.
 unset GOBIN
 
-OS_BUILD_TAGS=${OS_BUILD_TAGS-}
+STI_BUILD_TAGS=${STI_BUILD_TAGS-}

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -5,7 +5,7 @@ set -e
 source $(dirname $0)/config-go.sh
 
 find_test_dirs() {
-  cd src/${OS_GO_PACKAGE}
+  cd src/${STI_GO_PACKAGE}
   find . -not \( \
       \( \
         -wholename './third_party' \
@@ -16,7 +16,7 @@ find_test_dirs() {
         -o -wholename '*/Godeps/*' \
         -o -wholename '*/_output/*' \
       \) -prune \
-    \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${OS_GO_PACKAGE}/%s\n"
+    \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${STI_GO_PACKAGE}/%s\n"
 }
 
 # there is currently a race in the coverage code in tip.  Remove this when it is fixed
@@ -35,14 +35,14 @@ if [ -z ${STI_RACE+x} ]; then
   STI_RACE="-race"
 fi
 
-cd "${OS_TARGET}"
+cd "${STI_TARGET}"
 
 if [ "$1" != "" ]; then
   if [ -n "${STI_COVER}" ]; then
     STI_COVER="${STI_COVER} -coverprofile=tmp.out"
   fi
 
-  go test $STI_RACE $STI_TIMEOUT $STI_COVER "$OS_GO_PACKAGE/$1" "${@:2}"
+  go test $STI_RACE $STI_TIMEOUT $STI_COVER "$STI_GO_PACKAGE/$1" "${@:2}"
   exit 0
 fi
 


### PR DESCRIPTION
Update build-release to match latest state of openshift/origin. It now uses a docker image to create releases for mac(darwin), win, and linux(amd64)
