### PR TITLE
Fix hang in incremental build

### DIFF
--- a/pkg/sti/build_test.go
+++ b/pkg/sti/build_test.go
@@ -262,7 +262,6 @@ func TestSaveArtifactsRunError(t *testing.T) {
 		errors.ErrSaveArtifactsFailed,
 	}
 	// test with tar extract error or not
-	// the result should remain the same
 	tarError := []bool{true, false}
 	for i, _ := range tests {
 		for _, te := range tarError {
@@ -274,8 +273,10 @@ func TestSaveArtifactsRunError(t *testing.T) {
 				th.ExtractTarError = fmt.Errorf("tar error")
 			}
 			err := bh.saveArtifacts()
-			if err != expected[i] {
+			if !te && err != expected[i] {
 				t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+			} else if te && err != th.ExtractTarError {
+				t.Errorf("Expected tar error. Got %v", err)
 			}
 		}
 	}

--- a/pkg/sti/tar/tar.go
+++ b/pkg/sti/tar/tar.go
@@ -15,7 +15,7 @@ import (
 // defaultTimeout is the amount of time that the untar will wait for a tar
 // stream to extract a single file. A timeout is needed to guard against broken
 // connections in which it would wait for a long time to untar and nothing would happen
-const defaultTimeout = 2 * time.Minute
+const defaultTimeout = 5 * time.Second
 
 // defaultExclusionPattern is the pattern of files that will not be included in a tar
 // file when creating one. By default it is any file inside a .git metadata directory


### PR DESCRIPTION
Incremental builds were hanging because both build.go and docker.go were waiting on each other. To fix it, I simplified the code and no longer use multiple go routines in build.go#saveArtifacts
