### PR TITLE
Make the error messages about downloading STI scripts more friendly

### DIFF
--- a/pkg/sti/docker/docker.go
+++ b/pkg/sti/docker/docker.go
@@ -132,15 +132,15 @@ func (d *stiDocker) GetDefaultScriptsUrl(image string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var defaultScriptsUrl string
+	defaultScriptsUrl := ""
 	env := append(imageMetadata.ContainerConfig.Env, imageMetadata.Config.Env...)
 	for _, v := range env {
 		if strings.HasPrefix(v, "STI_SCRIPTS_URL=") {
-			defaultScriptsUrl = v[len("STI_SCRIPTS_URL="):]
+			defaultScriptsUrl = strings.TrimSpace((v[len("STI_SCRIPTS_URL="):]))
 			break
 		}
 	}
-	if d.verbose {
+	if d.verbose && len(defaultScriptsUrl) != 0 {
 		log.Printf("Image contains default script url '%s'", defaultScriptsUrl)
 	}
 	return defaultScriptsUrl, nil

--- a/pkg/sti/script/installer.go
+++ b/pkg/sti/script/installer.go
@@ -124,14 +124,16 @@ func (s *handler) download(scripts []string, workingDir string) error {
 	// Wait for the script downloads to finish.
 	wg.Wait()
 	for _, d := range downloads {
-		if len(d) == 0 {
+		if len(d) == 0 && len(defaultUrl) == 0 {
+			return fmt.Errorf("Unable to retrieve STI scripts as provided image does not specify STI_SCRIPTS_URL and '-s' argument was not used")
+		} else if len(d) == 0 {
 			return errors.ErrScriptsDownloadFailed
 		}
 	}
 
 	for _, e := range errs {
 		if len(e) > 0 {
-			return errors.ErrScriptsDownloadFailed
+			return fmt.Errorf("STI script download failed: %#v", e)
 		}
 	}
 


### PR DESCRIPTION
Give users more friendly message when they are trying to use `sti build` with non-STI image and without `-s` flag.
Additionally don't replace the download error with custom error, but return the original error to users.
