### PR TITLE
Fix build tags when including a repository and tag name

### DIFF
--- a/pkg/sti/docker/docker.go
+++ b/pkg/sti/docker/docker.go
@@ -294,9 +294,12 @@ func (d *stiDocker) GetImageId(imageName string) (string, error) {
 // CommitContainer commits a container to an image with a specific tag.
 // The new image ID is returned
 func (d *stiDocker) CommitContainer(opts CommitContainerOptions) (string, error) {
+
+	repository, tag := docker.ParseRepositoryTag(opts.Repository)
 	dockerOpts := docker.CommitContainerOptions{
 		Container:  opts.ContainerID,
-		Repository: opts.Repository,
+		Repository: repository,
+		Tag:        tag,
 	}
 	if opts.Command != nil {
 		config := docker.Config{


### PR DESCRIPTION
When a tag is appended to the repository as in 

```
sti build https://github.com/csrwng/simple-ruby.git openshift/ruby-20-centos test/image:001
```

The resulting image repository is named test/image:001 (as opposed to just test/image with a tag 001)

```
REPOSITORY                                         TAG                   IMAGE ID            CREATED             VIRTUAL SIZE
test/image:001                                     latest                68075c4924da        6 minutes ago       447.7 MB
```

Expected:

```
REPOSITORY                                         TAG                   IMAGE ID            CREATED             VIRTUAL SIZE
test/image                                         001                   68075c4924da        6 minutes ago       447.7 MB
```
