### PR TITLE
Bug 1167191 - Added proper symlink handling when tarring

### DIFF
--- a/pkg/sti/build.go
+++ b/pkg/sti/build.go
@@ -99,8 +99,10 @@ func (b *Builder) Build() (*STIResult, error) {
 }
 
 func (h *buildHandler) PostExecute(containerID string, cmd []string) error {
-	var err error
-	var previousImageID = ""
+	var (
+		err             error
+		previousImageID string
+	)
 	if h.request.incremental && h.request.RemovePreviousImage {
 		if previousImageID, err = h.docker.GetImageId(h.request.Tag); err != nil {
 			glog.Errorf("Error retrieving previous image's metadata: %v", err)

--- a/pkg/sti/util/callback.go
+++ b/pkg/sti/util/callback.go
@@ -45,9 +45,10 @@ func (c *callbackInvoker) ExecuteCallback(callbackUrl string, success bool, mess
 	jsonWriter.Encode(d)
 	writer.Flush()
 
-	var resp *http.Response
-	var err error
-
+	var (
+		resp *http.Response
+		err  error
+	)
 	for retries := 0; retries < 3; retries++ {
 		resp, err = c.postFunc(callbackUrl, "application/json", jsonBuffer)
 		if err != nil {

--- a/pkg/sti/util/download_test.go
+++ b/pkg/sti/util/download_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 )
@@ -104,10 +105,14 @@ func getDownloader() (Downloader, *FakeSchemeReader) {
 func TestDownloadFile(t *testing.T) {
 	dl, fr := getDownloader()
 	fr.content = "test file content"
-	temp, _ := ioutil.TempFile("", "testdownload")
+	temp, err := ioutil.TempFile("", "testdownload")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	defer os.Remove(temp.Name())
 	u, _ := url.Parse("http://www.test.url/a/file")
 	temp.Close()
-	err := dl.DownloadFile(u, temp.Name())
+	err = dl.DownloadFile(u, temp.Name())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
The problem described in [BZ#1167191](https://bugzilla.redhat.com/show_bug.cgi?id=1167191) is caused by wrong link handling when tarring.  

//fyi @mfojtik @csrwng 
