### PR TITLE
Fixing output from cobra, when error occured.

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -167,5 +167,7 @@ func main() {
 	setupGlog(stiCmd.PersistentFlags())
 
 	err := stiCmd.Execute()
-	checkErr(err)
+	if err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This fixes following problem:

```
$ sti usage --unknown
unknown flag: --unknown

Usage: 
  sti [flags]
  sti [command]

Available Commands: 
  version                      Display version
  build <source> <image> <tag> Build a new image
  usage <image>                Print usage of the assemble script associated with the image
  help [command]               Help about any command

 Available Flags:
  -h, --help=false: help for sti
      --loglevel=0: Set the level of log output (0-3)
      --savetempdir=false: Save the temporary directory used by STI instead of deleting it
  -U, --url="unix:///var/run/docker.sock": Set the url of the docker socket to use

Use "sti help [command]" for more information about that command.
F1209 14:18:06.791831 23686 main.go:146] An error occurred: unknown flag: --unknown
Usage of sti:
      --loglevel=0: Set the level of log output (0-3)
      --savetempdir=false: Save the temporary directory used by STI instead of deleting it
  -U, --url="unix:///var/run/docker.sock": Set the url of the docker socket to use
```

The bottom lines (starting with `F1209 14:18:06.79...` and down) is unnecessary, since cobra already provides all the information for us.
