### PR TITLE
Bug 1118597 - sources are download inside executor method

### DIFF
--- a/pkg/sti/build_test.go
+++ b/pkg/sti/build_test.go
@@ -105,15 +105,14 @@ func testBuildHandler() *buildHandler {
 	requestHandler := &requestHandler{
 		docker:    &test.FakeDocker{},
 		installer: &test.FakeInstaller{},
+		git:       &test.FakeGit{},
 		fs:        &test.FakeFileSystem{},
 		tar:       &test.FakeTar{},
-
-		request: &Request{},
-		result:  &Result{},
+		request:   &Request{},
+		result:    &Result{},
 	}
 	buildHandler := &buildHandler{
 		requestHandler:  requestHandler,
-		git:             &test.FakeGit{},
 		callbackInvoker: &test.FakeCallbackInvoker{},
 	}
 

--- a/pkg/sti/executor_test.go
+++ b/pkg/sti/executor_test.go
@@ -11,11 +11,11 @@ func testRequestHandler() *requestHandler {
 	return &requestHandler{
 		docker:    &test.FakeDocker{},
 		installer: &test.FakeInstaller{},
+		git:       &test.FakeGit{},
 		fs:        &test.FakeFileSystem{},
 		tar:       &test.FakeTar{},
-
-		request: &Request{},
-		result:  &Result{},
+		request:   &Request{},
+		result:    &Result{},
 	}
 }
 

--- a/pkg/sti/usage.go
+++ b/pkg/sti/usage.go
@@ -3,7 +3,7 @@ package sti
 // UsageHandler handles a request to display usage
 type usageHandler interface {
 	cleanup()
-	setup(required []string, optional []string) error
+	setup(requiredScripts, optionalScripts []string) error
 	execute(command string) error
 }
 


### PR DESCRIPTION
Sources are downloaded inside executor method, previously they were downloaded inside Build method which resulted in them not being taken under consideration when searching sti scripts.
