### PR TITLE
fix #106 build with source from local file system

### DIFF
--- a/pkg/sti/executor.go
+++ b/pkg/sti/executor.go
@@ -274,7 +274,8 @@ func (h *requestHandler) cleanup() {
 }
 
 func (h *requestHandler) fetchSource() error {
-	targetSourceDir := filepath.Join(h.request.WorkingDir, "upload", "src")
+	uploadDir := filepath.Join(h.request.WorkingDir, "upload");
+	targetSourceDir := filepath.Join(uploadDir, "src")
 	glog.V(1).Infof("Downloading %s to directory %s", h.request.Source, targetSourceDir)
 	if h.git.ValidCloneSpec(h.request.Source) {
 		if err := h.git.Clone(h.request.Source, targetSourceDir); err != nil {
@@ -290,7 +291,12 @@ func (h *requestHandler) fetchSource() error {
 			}
 		}
 	} else {
-		h.fs.Copy(h.request.Source, targetSourceDir)
+		if err := h.fs.Mkdir(uploadDir); err != nil {
+			return err
+		}
+		if err := h.fs.Copy(h.request.Source, targetSourceDir); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
 and handle errors from shell commands.

Note that this doesn't address the regular output of shell commands, which still need to be integrated into the logging framework.