### PR TITLE
[DO NOT MERGE] Make run script optional

### DIFF
--- a/docs/builder_image.md
+++ b/docs/builder_image.md
@@ -39,8 +39,8 @@ sources are already there.
 
 * required:
     * [assemble](#assemble)
-    * [run](#run)
 * optional:
+    * [run](#run)
     * [save-artifacts](#save-artifacts)
     * [usage](#usage)
 
@@ -85,7 +85,7 @@ popd
 
 ## run
 
-The `run` script is responsible for executing your application.
+The `run` script is responsible for executing your application. If the script is not provided, the `CMD` specified in the STI builder image will be used as-is.
 
 #### Example `run` script:
 

--- a/pkg/sti/docker/docker.go
+++ b/pkg/sti/docker/docker.go
@@ -28,6 +28,7 @@ type Docker interface {
 	GetScriptsURL(name string) (string, error)
 	RunContainer(opts RunContainerOptions) error
 	GetImageID(name string) (string, error)
+	GetBuilderImage(name string) (*docker.Image, error)
 	CommitContainer(opts CommitContainerOptions) (string, error)
 	RemoveImage(name string) error
 	PullImage(name string) error
@@ -40,6 +41,7 @@ type Docker interface {
 type Client interface {
 	RemoveImage(name string) error
 	InspectImage(name string) (*docker.Image, error)
+	InspectContainer(name string) (*docker.Container, error)
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error)
 	AttachToContainer(opts docker.AttachToContainerOptions) error
@@ -336,6 +338,23 @@ func (d *stiDocker) GetImageID(name string) (string, error) {
 		return "", err
 	}
 	return image.ID, nil
+}
+
+// This function resolves the original (ie. not created by STI) parent image
+// and returns it for the container specified as the input.
+func (d *stiDocker) GetBuilderImage(name string) (*docker.Image, error) {
+	container, err := d.client.InspectContainer(name)
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := d.client.InspectImage(container.Image)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return image, nil
 }
 
 // CommitContainer commits a container to an image with a specific tag.


### PR DESCRIPTION
This makes the `run` script optional. In case the run script is not provided, the `CMD` used in the builder image will be reused.

Fixes #114.

**Warning**
This is work in progress. Currently it always uses the `CMD` set in the builder image and ignores the provided `run` script.