### PR TITLE
Initialize Flags on the spot

### DIFF
--- a/pkg/sti/config/config.go
+++ b/pkg/sti/config/config.go
@@ -28,9 +28,9 @@ func Save(req *api.Request, cmd *cobra.Command) {
 		BaseImage: req.BaseImage,
 		Source:    req.Source,
 		Tag:       req.Tag,
+		Flags:     make(map[string]string),
 	}
-	c.Flags = make(map[string]string)
-	// Store only flags that has changed
+	// Store only flags that have changed
 	cmd.Flags().Visit(func(f *pflag.Flag) {
 		c.Flags[f.Name] = f.Value.String()
 	})


### PR DESCRIPTION
Initialize Flags alongside the rest initialization of Config so that the
underlying map reference will point to an initialized map and not nil
which can cause runtime panics if someone tries to write to it in between
the Config initialization and the [current](https://github.com/openshift/source-to-image/blob/9fad846d68808d43a815072db4d075cbe5012c05/pkg/sti/config/config.go#L32) map initialization
(blog.golang.org/go-maps-in-action)