### PR TITLE
Card devexp_426 - Renaming Clean to Incremental to better match current behaviour, where Incremental needs to be forced

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -106,7 +106,7 @@ func newCmdBuild(req *api.Request) *cobra.Command {
 		},
 	}
 
-	buildCmd.Flags().BoolVar(&(req.Clean), "clean", true, "Perform a clean build")
+	buildCmd.Flags().BoolVar(&(req.Incremental), "incremental", false, "Perform an incremental build")
 	buildCmd.Flags().BoolVar(&(req.RemovePreviousImage), "rm", false, "Remove the previous image during incremental builds")
 	buildCmd.Flags().StringP("env", "e", "", "Specify an environment var NAME=VALUE,NAME2=VALUE2,...")
 	buildCmd.Flags().StringVarP(&(req.Ref), "ref", "r", "", "Specify a ref to check-out")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 | Name                       | Description                                             |
 |:-------------------------- |:--------------------------------------------------------|
 | `--callbackURL`            | URL to be invoked after successful build (see [Callback URL](#callback-url)) |
-| `--clean`                  | Always perform clean build, even if build is eligible for incremental one (default: `true`) |
+| `--incremental`            | Try performing an incremental build |
 | `-e (--env)`               | Environment variables passed to the builder eg. `NAME=VALUE,NAME2=VALUE2,...` |
 | `--forcePull`              | Always pull the builder image, even if it is present locally |
 | `-l (--location)`          | Location where the scripts and sources will be placed prior doing build (see [STI Scripts](#sti-scripts))|

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -21,8 +21,8 @@ type Request struct {
 	// Tag is a result image tag name.
 	Tag string
 
-	// Clean describes whether to perform full build even if the build is eligible for incremental build.
-	Clean bool
+	// Incremental describes whether to try to perform incremental build.
+	Incremental bool
 
 	// RemovePreviousImage describes if previous image should be removed after successful build.
 	// This applies only to incremental builds.
@@ -42,9 +42,6 @@ type Request struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
-
-	// Incremental describes incremental status of current build
-	Incremental bool
 
 	// WorkingDir describes temporary directory used for downloading sources, scripts and tar operations.
 	WorkingDir string

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -175,7 +175,7 @@ func (i *integrationTest) exerciseCleanBuild(tag string, verifyCallback bool, im
 		BaseImage:    imageName,
 		Source:       TestSource,
 		Tag:          tag,
-		Clean:        true,
+		Incremental:  false,
 		CallbackURL:  callbackURL,
 		ScriptsURL:   scriptsURL}
 
@@ -230,7 +230,7 @@ func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, remove
 		BaseImage:           imageName,
 		Source:              TestSource,
 		Tag:                 tag,
-		Clean:               true,
+		Incremental:         false,
 		RemovePreviousImage: removePreviousImage,
 	}
 
@@ -252,7 +252,7 @@ func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, remove
 		BaseImage:           imageName,
 		Source:              TestSource,
 		Tag:                 tag,
-		Clean:               false,
+		Incremental:         true,
 		RemovePreviousImage: removePreviousImage,
 	}
 


### PR DESCRIPTION
After talking to @mfojtik we've decided to rename the `Clean` variable to `Incremental` to better match current behavior. This came up when doing https://github.com/openshift/origin/pull/1101.

/cc @bparees 