### PR TITLE
Renaming ruby-20-centos to new ruby-20-centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can start using `sti` right away (see [releases](https://github.com/openshif
 with the following test sources and publicly available images:
 
 ```
-$ sti build git://github.com/pmorie/simple-ruby openshift/ruby-20-centos test-ruby-app
+$ sti build git://github.com/pmorie/simple-ruby openshift/ruby-20-centos7 test-ruby-app
 $ docker run --rm -i -p :9292 -t test-ruby-app
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,11 +124,11 @@ sources and artifacts.
 
 #### Example Usage
 
-Build a ruby application from a GIT source, using the official `ruby-20-centos` builder
+Build a ruby application from a GIT source, using the official `ruby-20-centos7` builder
 image, the resulting image will be named `ruby-app`:
 
 ```
-$ sti build git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos ruby-app
+$ sti build git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 Build a nodejs application from a local directory, using a local image, the resulting
@@ -147,10 +147,10 @@ $ sti build --scripts=file://stiscripts git://github.com/bparees/openshift-jee-s
 ```
 
 Build a ruby application from a GIT source, specifying `ref`, using the official
-`ruby-20-centos` builder image, the resulting image will be named `ruby-app`:
+`ruby-20-centos7` builder image, the resulting image will be named `ruby-app`:
 
 ```
-$ sti build --ref=my-branch git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos ruby-app
+$ sti build --ref=my-branch git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 If the ref is invalid or not present in the source repository, the build will fail.
@@ -159,7 +159,7 @@ Build a ruby application from a GIT source, overriding the scripts URL from a lo
 and forcing the scripts and sources to be placed in `/opt` directory:
 
 ```
-$ sti build --scripts=file://stiscripts --location=/opt git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos ruby-app
+$ sti build --scripts=file://stiscripts --location=/opt git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 
@@ -181,9 +181,9 @@ the only parameter.
 
 #### Example Usage
 
-Print the official `ruby-20-centos` builder image usage:
+Print the official `ruby-20-centos7` builder image usage:
 ```
-$ sti usage openshift/ruby-20-centos
+$ sti usage openshift/ruby-20-centos7
 ```
 
 


### PR DESCRIPTION
This is a part of work on https://trello.com/c/UJG1mPZf/364-3-v3-ruby-image-image-beta2
Also last step before we cant get rid of the ruby-20-centos repository