### PR TITLE
Bug 1196967 - fixed version information

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -312,7 +312,7 @@ sti::build::sti_version_vars() {
     fi
 
     # Use git describe to find the version based on annotated tags.
-    if [[ -n ${STI_GIT_VERSION-} ]] || STI_GIT_VERSION=$("${git[@]}" describe --abbrev=14 "${STI_GIT_COMMIT}^{commit}" 2>/dev/null); then
+    if [[ -n ${STI_GIT_VERSION-} ]] || STI_GIT_VERSION=$("${git[@]}" describe "${STI_GIT_COMMIT}^{commit}" 2>/dev/null); then
       if [[ "${STI_GIT_TREE_STATE}" == "dirty" ]]; then
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,
@@ -364,7 +364,10 @@ sti::build::ldflags() {
     sti::build::get_version_vars
 
     declare -a ldflags=()
-    ldflags+=(-X "${STI_GO_PACKAGE}/pkg/sti/version.commitFromGit" "${STI_GIT_COMMIT}")
+    ldflags+=(-X "${STI_GO_PACKAGE}/pkg/version.majorFromGit" "${STI_GIT_MAJOR}")
+    ldflags+=(-X "${STI_GO_PACKAGE}/pkg/version.minorFromGit" "${STI_GIT_MINOR}")
+    ldflags+=(-X "${STI_GO_PACKAGE}/pkg/version.versionFromGit" "${STI_GIT_VERSION}")
+    ldflags+=(-X "${STI_GO_PACKAGE}/pkg/version.commitFromGit" "${STI_GIT_COMMIT}")
 
     # The -ldflags parameter takes a single string, so join the output.
     echo "${ldflags[*]-}"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,37 +1,42 @@
 package version
 
-import (
-	"fmt"
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit string
+	// major version
+	majorFromGit string
+	// minor version
+	minorFromGit string
 )
 
-// commitFromGit is a constant representing the source version that
-// generated this build. It should be set during build via -ldflags.
-var commitFromGit string
-
 // Info contains versioning information.
-// TODO: Add []string of api versions supported? It's still unclear
-// how we'll want to distribute that information.
 type Info struct {
-	Major     string `json:"major" yaml:"major"`
-	Minor     string `json:"minor" yaml:"minor"`
-	GitCommit string `json:"gitCommit" yaml:"gitCommit"`
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
+	GitCommit  string `json:"gitCommit"`
+	GitVersion string `json:"gitVersion"`
 }
 
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func Get() Info {
 	return Info{
-		Major:     "0",
-		Minor:     "1",
-		GitCommit: commitFromGit,
+		Major:      majorFromGit,
+		Minor:      minorFromGit,
+		GitCommit:  commitFromGit,
+		GitVersion: versionFromGit,
 	}
 }
 
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
-	commit := info.GitCommit
-	if commit == "" {
-		commit = "(unknown)"
+	version := info.GitVersion
+	if version == "" {
+		version = "unknown"
 	}
-	return fmt.Sprintf("version %s.%s, build %s", info.Major, info.Minor, commit)
+	return version
 }


### PR DESCRIPTION
Fixed some leftovers in the release process, especially the binary version which was trying to modify old package `pkg/sti/version` instead of `pkg/version`.

@bparees PTAL