### PR TITLE
Add --assembleOutput=true to sti build command

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -108,6 +108,7 @@ func newCmdBuild(req *api.Request) *cobra.Command {
 		},
 	}
 
+	buildCmd.Flags().BoolVar(&(req.AssembleOutput), "assembleOutput", true, "Print the output from assemble script to console")
 	buildCmd.Flags().BoolVar(&(req.Incremental), "incremental", false, "Perform an incremental build")
 	buildCmd.Flags().BoolVar(&(req.RemovePreviousImage), "rm", false, "Remove the previous image during incremental builds")
 	buildCmd.Flags().StringP("env", "e", "", "Specify an environment var NAME=VALUE,NAME2=VALUE2,...")
@@ -198,7 +199,8 @@ func checkErr(err error) {
 			"providing us with a log from your build using --loglevel=3")
 		os.Exit(e.ErrorCode)
 	} else {
-		glog.Fatalf("An error occurred: %v", err)
+		glog.V(1).Infof("An error occurred: %v", err)
+		os.Exit(1)
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -54,6 +54,10 @@ type Request struct {
 	// (see ONBUILD strategy). The default value is "upload/scripts".
 	InstallDestination string
 
+	// Print the output from the assemble script to console if set to true
+	// (default).
+	AssembleOutput bool
+
 	// Specify a relative directory inside the application repository that should
 	// be used as a root directory for the application.
 	ContextDir string

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -108,7 +108,7 @@ func New(req *api.Request) (*STI, error) {
 func (b *STI) Build(request *api.Request) (*api.Result, error) {
 	defer b.garbage.Cleanup(request)
 
-	glog.Infof("Building %s", request.Tag)
+	glog.V(1).Infof("Building %s", request.Tag)
 	if err := b.preparer.Prepare(request); err != nil {
 		return nil, err
 	}
@@ -232,10 +232,10 @@ func (b *STI) PostExecute(containerID string, location string) error {
 	b.result.ImageID = imageID
 
 	if len(b.request.Tag) > 0 {
-		glog.Infof("Successfully built %s", b.request.Tag)
+		glog.V(1).Infof("Successfully built %s", b.request.Tag)
 		glog.V(1).Infof("Tagged %s as %s", imageID, b.request.Tag)
 	} else {
-		glog.Infof("Successfully built %s", imageID)
+		glog.V(1).Infof("Successfully built %s", imageID)
 	}
 
 	if b.incremental && b.request.RemovePreviousImage && previousImageID != "" {
@@ -367,7 +367,7 @@ func (b *STI) Execute(command string, request *api.Request) error {
 				}
 				break
 			}
-			if glog.V(2) || command == api.Usage {
+			if glog.V(2) || request.AssembleOutput == true || command == api.Usage {
 				glog.Info(text)
 			}
 		}

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -25,7 +25,7 @@ func (c *Clone) Download(request *api.Request) error {
 		}
 		glog.V(2).Infof("Cloning into %s", targetSourceDir)
 		if err := c.Clone(request.Source, targetSourceDir); err != nil {
-			glog.Errorf("Git clone failed: %+v", err)
+			glog.V(1).Infof("Git clone failed: %+v", err)
 			return err
 		}
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -47,7 +47,7 @@ func TestGitClone(t *testing.T) {
 	if ch.Name != "git" {
 		t.Errorf("Unexpected command name: %s\n", ch.Name)
 	}
-	if !reflect.DeepEqual(ch.Args, []string{"clone", "--recursive", "source1", "target1"}) {
+	if !reflect.DeepEqual(ch.Args, []string{"clone", "--quiet", "--recursive", "source1", "target1"}) {
 		t.Errorf("Unexpected command arguments: %#v\n", ch.Args)
 	}
 }


### PR DESCRIPTION
With this `sti build` always streams the output from the `assemble` script to console (so users can see the build progress/warning/non-fatal errors without bumping loglevel).

Additionally I switched 'git' into quite mode (you don't really need to see the git clone command, only errors when the git fails). Also the git command output is now streamed via glog() to have consistent output.

The `assembleOutput=false` will make the output super-silent. Nothing is returned to users except errors.