### PR TITLE
Set permissions of installed scripts to world read/exec

### DIFF
--- a/pkg/scripts/install.go
+++ b/pkg/scripts/install.go
@@ -163,7 +163,7 @@ func (i *installer) install(scripts []string, userResults, sourceResults, defaul
 				continue
 			}
 			// set appropriate permissions
-			if err := i.fs.Chmod(dst, 0700); err != nil {
+			if err := i.fs.Chmod(dst, 0755); err != nil {
 				result.Error = err
 				continue
 			}


### PR DESCRIPTION
This makes it possible for users that are not the user building
the STI image to execute the image.