### PR TITLE
Allow passing DNS servers and search prefixes to build container

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -69,6 +69,12 @@ type Config struct {
 	// Specify a relative directory inside the application repository that should
 	// be used as a root directory for the application.
 	ContextDir string
+
+	// DNS servers to use when running build container
+	DNS []string
+
+	// DNS search suffixes to use when running build container
+	DNSSearch []string
 }
 
 // DockerConfig contains the configuration for a Docker connection

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -312,6 +312,8 @@ func (b *STI) Save(config *api.Config) (err error) {
 		Stdout:          outWriter,
 		Stderr:          errWriter,
 		OnStart:         extractFunc,
+		DNS:             config.DNS,
+		DNSSearch:       config.DNSSearch,
 	}
 
 	go streamContainerError(errReader, nil, config)
@@ -369,6 +371,8 @@ func (b *STI) Execute(command string, config *api.Config) error {
 		Command:         command,
 		Env:             buildEnv,
 		PostExec:        b.postExecutor,
+		DNS:             config.DNS,
+		DNSSearch:       config.DNSSearch,
 	}
 	if !config.LayeredBuild {
 		opts.Stdin = tarFile

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -88,6 +88,8 @@ type RunContainerOptions struct {
 	Stderr          io.Writer
 	OnStart         func() error
 	PostExec        PostExecutor
+	DNS             []string
+	DNSSearch       []string
 }
 
 // CommitContainerOptions are options passed in to the CommitContainer method
@@ -346,9 +348,16 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) (err error) {
 	if opts.Stdout != nil {
 		config.AttachStdout = true
 	}
+	var hostConfig *docker.HostConfig
+	if opts.DNS != nil || opts.DNSSearch != nil {
+		hostConfig = &docker.HostConfig{
+			DNS:       opts.DNS,
+			DNSSearch: opts.DNSSearch,
+		}
+	}
 
-	glog.V(2).Infof("Creating container using config: %+v", config)
-	container, err := d.client.CreateContainer(docker.CreateContainerOptions{Name: "", Config: &config})
+	glog.V(2).Infof("Creating container using config: %+v and host config: %+v", config, hostConfig)
+	container, err := d.client.CreateContainer(docker.CreateContainerOptions{Name: "", Config: &config, HostConfig: hostConfig})
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -426,6 +426,7 @@ func TestRunContainer(t *testing.T) {
 			AttachToContainerSleep: 200 * time.Millisecond,
 		}
 		dh := getDocker(fakeDocker)
+		dnsServers := []string{"dnsserver1", "dnsserver2"}
 		err := dh.RunContainer(RunContainerOptions{
 			Image:           "test/image",
 			PullImage:       true,
@@ -437,6 +438,7 @@ func TestRunContainer(t *testing.T) {
 			Stdin:           os.Stdin,
 			Stdout:          os.Stdout,
 			Stderr:          os.Stdout,
+			DNS:             dnsServers,
 		})
 		if err != nil {
 			t.Errorf("%s: Unexpected error: %v", desc, err)
@@ -455,6 +457,13 @@ func TestRunContainer(t *testing.T) {
 		if !createConfig.OpenStdin || !createConfig.StdinOnce {
 			t.Errorf("%s: Unexpected stdin flags for createConfig: OpenStdin - %v"+
 				" StdinOnce - %v", desc, createConfig.OpenStdin, createConfig.StdinOnce)
+		}
+		hostConfig := fakeDocker.CreateContainerOpts.HostConfig
+		if hostConfig == nil {
+			t.Errorf("%s: Expected a valid hostConfig in createContainerOpts")
+		}
+		if hostConfig != nil && !reflect.DeepEqual(hostConfig.DNS, dnsServers) {
+			t.Errorf("%s: Unexpected hostConfig DNS value: %#v", hostConfig.DNS)
 		}
 
 		// Verify that remove container was called


### PR DESCRIPTION
Allows origin code to pass in DNS lookup info to container launched by STI