### PR TITLE
Add more metadata into output image

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -185,6 +185,8 @@ func newCmdBuild(cfg *api.Config) *cobra.Command {
 	buildCmd.Flags().StringVarP(&(cfg.ContextDir), "context-dir", "", "", "Specify the sub-directory inside the repository with the application sources")
 	buildCmd.Flags().StringVarP(&(cfg.DockerCfgPath), "dockercfg-path", "", filepath.Join(os.Getenv("HOME"), ".dockercfg"), "Specify the path to the Docker configuration file")
 	buildCmd.Flags().StringVarP(&(cfg.EnvironmentFile), "environment-file", "E", "", "Specify the path to the file with environment")
+	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
+	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
 
 	return buildCmd
 }

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -14,6 +14,12 @@ import (
 // Config returns the Config object in nice readable, tabbed format.
 func DescribeConfig(config *api.Config) string {
 	out, err := tabbedString(func(out io.Writer) error {
+		if len(config.DisplayName) > 0 {
+			fmt.Fprintf(out, "Application Name:\t%s\n", config.DisplayName)
+		}
+		if len(config.Description) > 0 {
+			fmt.Fprintf(out, "Description:\t%s\n", config.Description)
+		}
 		fmt.Fprintf(out, "Builder Image:\t%s\n", config.BuilderImage)
 		fmt.Fprintf(out, "Source:\t%s\n", config.Source)
 		if len(config.Ref) > 0 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,8 +2,20 @@ package api
 
 import docker "github.com/fsouza/go-dockerclient"
 
+const (
+	DefaultNamespace    = "io.openshift.s2i."
+	KubernetesNamespace = "io.k8s."
+)
+
 // Config contains essential fields for performing build.
 type Config struct {
+	// DisplayName is a result image display-name label. This defaults to the
+	// output image name.
+	DisplayName string
+
+	// Description is a result image description label. The default is no
+	// description.
+	Description string
 
 	// BuilderImage describes which image is used for building the result images.
 	BuilderImage string
@@ -120,4 +132,37 @@ type InstallResult struct {
 
 	// Error describes last error encountered during install operation
 	Error error
+}
+
+// SourceInfo stores information about the source code
+type SourceInfo struct {
+	// Ref represents a commit SHA-1, valid GIT branch name or a GIT tag
+	// The output image will contain this information as 'io.openshift.build.commit.ref' label.
+	Ref string
+
+	// CommitID represents an arbitrary extended object reference in GIT as SHA-1
+	// The output image will contain this information as 'io.openshift.build.commit.id' label.
+	CommitID string
+
+	// Date contains a date when the committer created the commit.
+	// The output image will contain this information as 'io.openshift.build.commit.date' label.
+	Date string
+
+	// Author contains information about the committer name and email address.
+	// The output image will contain this information as 'io.openshift.build.commit.author' label.
+	Author string
+
+	// Message represents the first 80 characters from the commit message.
+	// The output image will contain this information as 'io.openshift.build.commit.message' label.
+	Message string
+
+	// Location contains a valid URL to the original repository.
+	// The output image will contain this information as 'io.openshift.build.source-location' label.
+	Location string
+
+	// ContextDir contains path inside the Location directory that
+	// contains the application source code.
+	// The output image will contain this information as 'io.openshift.build.source-context-dir'
+	// label.
+	ContextDir string
 }

--- a/pkg/build/interfaces.go
+++ b/pkg/build/interfaces.go
@@ -38,7 +38,7 @@ type ScriptsHandler interface {
 
 // Downloader provides methods for downloading the application source code
 type Downloader interface {
-	Download(*api.Config) error
+	Download(*api.Config) (*api.SourceInfo, error)
 }
 
 // SourceHandler is a wrapper for STI strategy Downloader and Preparer which

--- a/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/pkg/build/strategies/onbuild/onbuild_test.go
@@ -19,8 +19,8 @@ func (*fakeSourceHandler) Prepare(r *api.Config) error {
 	return nil
 }
 
-func (*fakeSourceHandler) Download(r *api.Config) error {
-	return nil
+func (*fakeSourceHandler) Download(r *api.Config) (*api.SourceInfo, error) {
+	return &api.SourceInfo{}, nil
 }
 
 type fakeCleaner struct{}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -52,6 +52,7 @@ type STI struct {
 	installedScripts map[string]bool
 	scriptsURL       map[string]string
 	incremental      bool
+	sourceInfo       *api.SourceInfo
 
 	// Interfaces
 	preparer  build.Preparer
@@ -165,7 +166,7 @@ func (b *STI) Prepare(config *api.Config) error {
 
 	// fetch sources, for theirs .sti/bin might contain sti scripts
 	if len(config.Source) > 0 {
-		if err = b.source.Download(config); err != nil {
+		if b.sourceInfo, err = b.source.Download(config); err != nil {
 			return err
 		}
 	}
@@ -232,6 +233,7 @@ func (b *STI) PostExecute(containerID, location string) error {
 		Env:         buildEnv,
 		ContainerID: containerID,
 		Repository:  b.config.Tag,
+		Labels:      util.GenerateOutputImageLabels(b.sourceInfo, b.config),
 	}
 
 	imageID, err := b.docker.CommitContainer(opts)

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -522,7 +522,7 @@ func TestFetchSource(t *testing.T) {
 		}
 
 		expectedTargetDir := "/working-dir/upload/src"
-		e := bh.source.Download(bh.config)
+		_, e := bh.source.Download(bh.config)
 		if ft.expectedError == nil && e != nil {
 			t.Errorf("Unexpected error %v [%d]", e, testNum)
 		}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -96,6 +96,7 @@ type CommitContainerOptions struct {
 	Repository  string
 	Command     []string
 	Env         []string
+	Labels      map[string]string
 }
 
 // BuildImageOptions are options passed in to the BuildImage method
@@ -462,8 +463,9 @@ func (d *stiDocker) CommitContainer(opts CommitContainerOptions) (string, error)
 	}
 	if opts.Command != nil {
 		config := docker.Config{
-			Cmd: opts.Command,
-			Env: opts.Env,
+			Cmd:    opts.Command,
+			Env:    opts.Env,
+			Labels: opts.Labels,
 		}
 		dockerOpts.Run = &config
 		glog.V(2).Infof("Committing container with config: %+v", config)

--- a/pkg/git/clone_test.go
+++ b/pkg/git/clone_test.go
@@ -20,9 +20,12 @@ func TestCloneWithContext(t *testing.T) {
 		ContextDir: "subdir",
 		Ref:        "ref1",
 	}
-	err := c.Download(fakeConfig)
+	info, err := c.Download(fakeConfig)
 	if err != nil {
 		t.Errorf("%v", err)
+	}
+	if info == nil {
+		t.Fatalf("Expected info to be not nil")
 	}
 	if fs.CopySource != "upload/tmp/subdir/." {
 		t.Errorf("The source directory should be 'upload/tmp/subdir', it is %v", fs.CopySource)
@@ -50,7 +53,7 @@ func TestCloneLocalWithContext(t *testing.T) {
 		ContextDir: "subdir",
 		Ref:        "ref1",
 	}
-	err := c.Download(fakeConfig)
+	_, err := c.Download(fakeConfig)
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/pkg/scripts/download_test.go
+++ b/pkg/scripts/download_test.go
@@ -105,9 +105,12 @@ func TestDownload(t *testing.T) {
 	defer os.Remove(temp.Name())
 	u, _ := url.Parse("http://www.test.url/a/file")
 	temp.Close()
-	err = dl.Download(u, temp.Name())
+	info, err := dl.Download(u, temp.Name())
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(info.Location) == 0 {
+		t.Errorf("Expected info.Location to be set, got %v", info)
 	}
 	content, _ := ioutil.ReadFile(temp.Name())
 	if string(content) != fr.content {
@@ -122,7 +125,7 @@ func TestNoDownload(t *testing.T) {
 		},
 	}
 	u, _ := url.Parse("image:///tmp/testfile")
-	err := dl.Download(u, "")
+	_, err := dl.Download(u, "")
 	if err == nil {
 		t.Error("Expected error with information about scripts inside the image!")
 	}
@@ -136,7 +139,7 @@ func TestNoDownloader(t *testing.T) {
 		schemeReaders: map[string]schemeReader{},
 	}
 	u, _ := url.Parse("http://www.test.url/a/file")
-	err := dl.Download(u, "")
+	_, err := dl.Download(u, "")
 	if err == nil {
 		t.Errorf("Expected error, got nil!")
 	}

--- a/pkg/scripts/install.go
+++ b/pkg/scripts/install.go
@@ -110,7 +110,7 @@ func (i *installer) download(scriptsURL string, scripts []string, dstDir string)
 			result[script].err = err
 			continue
 		}
-		result[script].err = i.downloader.Download(url, filepath.Join(dstDir, script))
+		_, result[script].err = i.downloader.Download(url, filepath.Join(dstDir, script))
 	}
 
 	return result

--- a/pkg/test/download.go
+++ b/pkg/test/download.go
@@ -3,6 +3,8 @@ package test
 import (
 	"net/url"
 	"sync"
+
+	"github.com/openshift/source-to-image/pkg/api"
 )
 
 // FakeDownloader provides a fake downloader interface
@@ -14,12 +16,12 @@ type FakeDownloader struct {
 }
 
 // Download downloads a fake file from the URL
-func (f *FakeDownloader) Download(url *url.URL, target string) error {
+func (f *FakeDownloader) Download(url *url.URL, target string) (*api.SourceInfo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
 	f.URL = append(f.URL, *url)
 	f.Target = append(f.Target, target)
 
-	return f.Err[url.String()]
+	return &api.SourceInfo{Location: target, CommitID: "1bf4f04"}, f.Err[url.String()]
 }

--- a/pkg/test/git.go
+++ b/pkg/test/git.go
@@ -1,5 +1,7 @@
 package test
 
+import "github.com/openshift/source-to-image/pkg/api"
+
 // FakeGit provides a fake GIT
 type FakeGit struct {
 	ValidCloneSpecSource string
@@ -32,4 +34,12 @@ func (f *FakeGit) Checkout(repo, ref string) error {
 	f.CheckoutRepo = repo
 	f.CheckoutRef = ref
 	return f.CheckoutError
+}
+
+func (f *FakeGit) GetInfo(repo string) *api.SourceInfo {
+	return &api.SourceInfo{
+		Ref:      "master",
+		CommitID: "1bf4f04",
+		Location: "file:///foo",
+	}
 }

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+// GenerateOutputImageLabels generate the labels based on the source repository
+// informations.
+func GenerateOutputImageLabels(info *api.SourceInfo, config *api.Config) map[string]string {
+	result := map[string]string{}
+
+	if len(config.Description) > 0 {
+		result[api.KubernetesNamespace+"description"] = config.Description
+	}
+
+	if len(config.DisplayName) > 0 {
+		result[api.KubernetesNamespace+"display-name"] = config.DisplayName
+	} else {
+		result[api.KubernetesNamespace+"display-name"] = config.Tag
+	}
+
+	if info == nil {
+		glog.V(3).Infof("Unable to fetch source informations, the output image labels will not be set")
+		return result
+	}
+
+	addBuildLabel(result, "image", config.BuilderImage)
+	addBuildLabel(result, "commit.author", info.Author)
+	addBuildLabel(result, "commit.date", info.Date)
+	addBuildLabel(result, "commit.id", info.CommitID)
+	addBuildLabel(result, "commit.ref", info.Ref)
+	addBuildLabel(result, "commit.message", info.Message)
+	addBuildLabel(result, "source-location", info.Location)
+	addBuildLabel(result, "source-context-dir", config.ContextDir)
+
+	return result
+}
+
+// addBuildLabel adds a new "io.openshift.s2i.build.*" label into map when the
+// value of this label is not empty
+func addBuildLabel(to map[string]string, key, value string) {
+	if len(value) == 0 {
+		return
+	}
+	to[strings.Join([]string{api.DefaultNamespace, "build.", key}, "")] = value
+}


### PR DESCRIPTION
This PR will make s2i store more metadata about the source code the image was built from.  This will help debugging problems as you can later, in runtime identify what revision of the app is the container running.