### PR TITLE
Add `sti rebuild` command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,6 +138,23 @@ and forcing the scripts and sources to be placed in `/opt` directory:
 $ sti build --scripts-url=file://stiscripts --destination=/opt git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
+# sti rebuild
+
+The `sti rebuild` command is used to rebuild an image already built using S2I,
+or the image that contains the required S2I labels.
+The rebuild will read the S2I labels and automatically set the builder image,
+source repository and other configuration options used to build the previous
+image according to the stored labels values.
+
+Optionally, you can set the new image name as a second argument to the rebuild
+command.
+
+Usage:
+
+```
+$ sti rebuild <image name> [<new-tag-name>]
+```
+
 
 # sti usage
 

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -1,0 +1,53 @@
+package build
+
+import (
+	"fmt"
+
+	dockerclient "github.com/fsouza/go-dockerclient"
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
+)
+
+// GenerateConfigFromLabels generates the S2I Config struct from the Docker
+// image labels.
+func GenerateConfigFromLabels(image string, config *api.Config) error {
+	d, err := docker.New(config.DockerConfig, config.PullAuthentication)
+	if err != nil {
+		return err
+	}
+
+	var source *dockerclient.Image
+	if config.ForcePull {
+		source, err = d.PullImage(config.BuilderImage)
+	} else {
+		source, err = d.CheckAndPull(config.Tag)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if builder, ok := source.Config.Labels[api.DefaultNamespace+"build.image"]; ok {
+		config.BuilderImage = builder
+	} else {
+		return fmt.Errorf("Required label %q not found in image", api.DefaultNamespace+"build.image")
+	}
+
+	if repo, ok := source.Config.Labels[api.DefaultNamespace+"build.source-location"]; ok {
+		config.Source = repo
+	} else {
+		return fmt.Errorf("Required label %q not found in image", api.DefaultNamespace+"source-location")
+	}
+
+	config.ContextDir = source.Config.Labels[api.DefaultNamespace+"build.source-context-dir"]
+	config.Ref = source.Config.Labels[api.DefaultNamespace+"build.commit.ref"]
+	config.Description = source.Config.Labels[api.KubernetesNamespace+"description"]
+	config.DisplayName = source.Config.Labels[api.KubernetesNamespace+"display-name"]
+
+	config.ScriptsURL = source.Config.Labels[api.DefaultNamespace+"scripts-url"]
+	if len(config.ScriptsURL) == 0 {
+		// FIXME: Backward compatibility
+		config.ScriptsURL = source.Config.Labels["io.s2i.scripts-url"]
+	}
+	return nil
+}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -124,7 +124,10 @@ func (b *STI) Build(config *api.Config) (*api.Result, error) {
 	glog.V(2).Infof("Performing source build from %s", config.Source)
 	if b.incremental {
 		if err := b.artifacts.Save(config); err != nil {
-			glog.Warningf("Clean build will be performed becase of error saving previous build artifacts: %v", err)
+			glog.Warningf("Clean build will be performed because of error saving previous build artifacts")
+			if glog.V(2) {
+				glog.Infof("ERROR: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This command allows you to rebuild the existing S2I image (if the existing S2I image has the required LABEL(s) set).

Example:

```console
π ~/sandbox/ruby sti rebuild testapp --force-pull=false
Already on 'master-foo'
Your branch is up-to-date with 'origin/master-foo'.
W0626 13:06:29.347093 30851 docker.go:263] The 'io.s2i.scripts-url' label is deprecated. Use "io.openshift.s2i.scripts-url" instead.
W0626 13:06:31.133542 30851 sti.go:127] Clean build will be performed becase of error saving previous build artifacts
I0626 13:06:31.706939 30851 sti.go:393] ---> Installing application source
I0626 13:06:31.708994 30851 sti.go:393] ---> Building your Ruby application from source
I0626 13:06:31.709175 30851 sti.go:393] ---> Running 'bundle install --deployment'
I0626 13:06:37.391292 30851 sti.go:393] Fetching gem metadata from https://rubygems.org/..........
I0626 13:06:40.048308 30851 sti.go:393] Installing rack (1.6.0) 
I0626 13:06:40.328619 30851 sti.go:393] Installing rack-protection (1.5.3) 
I0626 13:06:40.723442 30851 sti.go:393] Installing tilt (1.4.1) 
I0626 13:06:41.450890 30851 sti.go:393] Installing sinatra (1.4.5) 
I0626 13:06:41.451446 30851 sti.go:393] Using bundler (1.3.5) 
I0626 13:06:41.452288 30851 sti.go:393] Your bundle is complete!
I0626 13:06:41.452319 30851 sti.go:393] It was installed into ./bundle
I0626 13:06:41.467110 30851 sti.go:393] ---> Cleaning up unused ruby gems
```