### PR TITLE
Add flag to prevent builders from running as root

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -188,6 +188,7 @@ func newCmdBuild(cfg *api.Config) *cobra.Command {
 	buildCmd.Flags().StringVarP(&(cfg.EnvironmentFile), "environment-file", "E", "", "Specify the path to the file with environment")
 	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
+	buildCmd.Flags().BoolVar(&(cfg.NoRoot), "no-root", false, "Do not allow using a builder image that will run as root")
 
 	return buildCmd
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -81,6 +81,12 @@ type Config struct {
 	// Specify a relative directory inside the application repository that should
 	// be used as a root directory for the application.
 	ContextDir string
+
+	// NoRoot specifies whether builder images are allowed to run as root. If set to true,
+	// a build will not proceed unless the USER specified in the builder image is numeric and not 0.
+	// If the image includes ONBUILD instructions, the build will not proceed if any of those
+	// instructions includes a USER directive.
+	NoRoot bool
 }
 
 // DockerConfig contains the configuration for a Docker connection

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -165,6 +165,59 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestCheckNoRoot(t *testing.T) {
+	tests := []struct {
+		noRoot    bool
+		user      string
+		expectErr bool
+	}{
+		{
+			noRoot:    false,
+			expectErr: false,
+			user:      "0",
+		},
+		{
+			noRoot:    false,
+			expectErr: false,
+			user:      "root",
+		},
+		{
+			noRoot:    true,
+			user:      "",
+			expectErr: true,
+		},
+		{
+			noRoot:    true,
+			user:      "100",
+			expectErr: false,
+		},
+		{
+			noRoot:    true,
+			user:      "default",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		cfg := &api.Config{
+			NoRoot: tc.noRoot,
+		}
+		builder := &STI{
+			docker: &test.FakeDocker{
+				GetImageUserResult: tc.user,
+			},
+		}
+		err := builder.checkNoRoot(cfg)
+		if err != nil && !tc.expectErr {
+			t.Errorf("Unexpected error: %v for test case: %#v\n", err, tc)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("Expected error, but did not get any for test case: %#v\n", tc)
+		}
+	}
+
+}
+
 func TestLayeredBuild(t *testing.T) {
 	fh := &FakeSTI{
 		BuildRequest: &api.Config{
@@ -317,7 +370,7 @@ func TestPostExecute(t *testing.T) {
 		}
 		// Ensure Callback was called
 		if ci.CallbackURL != bh.config.CallbackURL {
-			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %", i, bh.config.CallbackURL, ci.CallbackURL)
+			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %s", i, bh.config.CallbackURL, ci.CallbackURL)
 		}
 	}
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -47,6 +47,7 @@ const (
 type Docker interface {
 	IsImageInLocalRegistry(name string) (bool, error)
 	IsImageOnBuild(string) bool
+	GetOnBuild(string) ([]string, error)
 	RemoveContainer(id string) error
 	GetScriptsURL(name string) (string, error)
 	RunContainer(opts RunContainerOptions) error
@@ -176,12 +177,19 @@ func (d *stiDocker) GetImageUser(name string) (string, error) {
 // IsImageOnBuild provides information about whether the Docker image has
 // OnBuild instruction recorded in the Image Config.
 func (d *stiDocker) IsImageOnBuild(name string) bool {
+	onbuild, err := d.GetOnBuild(name)
+	return err == nil && len(onbuild) > 0
+}
+
+// GetOnBuild returns the set of ONBUILD Dockerfile commands to execute
+// for the given image
+func (d *stiDocker) GetOnBuild(name string) ([]string, error) {
 	name = getImageName(name)
 	image, err := d.client.InspectImage(name)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	return len(image.Config.OnBuild) > 0
+	return image.Config.OnBuild, nil
 }
 
 // CheckAndPullImage pulls an image into the local registry if not present

--- a/pkg/test/docker.go
+++ b/pkg/test/docker.go
@@ -23,6 +23,9 @@ type FakeDocker struct {
 	RunContainerErrorBeforeStart bool
 	RunContainerContainerID      string
 	RunContainerCmd              []string
+	GetOnBuildResult             []string
+	GetOnBuildError              error
+	GetOnBuildImage              string
 	GetImageIDImage              string
 	GetImageIDResult             string
 	GetImageIDError              error
@@ -48,8 +51,15 @@ func (f *FakeDocker) IsImageInLocalRegistry(imageName string) (bool, error) {
 	return f.LocalRegistryResult, f.LocalRegistryError
 }
 
+// IsImageOnBuild returns true if the image has onbuild instructions
 func (f *FakeDocker) IsImageOnBuild(imageName string) bool {
 	return false
+}
+
+// GetOnBuild returns the list of onbuild instructions for the image
+func (f *FakeDocker) GetOnBuild(imageName string) ([]string, error) {
+	f.GetOnBuildImage = imageName
+	return f.GetOnBuildResult, f.GetOnBuildError
 }
 
 // RemoveContainer removes a fake Docker container

--- a/pkg/util/checkroot.go
+++ b/pkg/util/checkroot.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// IsPotentialRootUser will return true if the passed in
+// user is blank, non-numeric, OR it's numeric and == 0
+func IsPotentialRootUser(user string) bool {
+	uid, err := strconv.Atoi(user)
+	return err != nil || uid == 0
+}
+
+var dockerLineDelim = regexp.MustCompile(`[\t\v\f\r ]+`)
+
+// IncludesRootUserDirective takes a list of Dockerfile instructions
+// and returns true if they include one with a "USER" directive
+// and the specified user is a potential root user
+func IncludesRootUserDirective(directives []string) bool {
+	for _, line := range directives {
+		parts := dockerLineDelim.Split(line, 2)
+		if strings.ToLower(parts[0]) != "user" {
+			continue
+		}
+		if IsPotentialRootUser(parts[1]) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/checkroot_test.go
+++ b/pkg/util/checkroot_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestIsPotentialRootUser(t *testing.T) {
+	tests := []struct {
+		str      string
+		expected bool
+	}{
+		{
+			str:      "145",
+			expected: false,
+		},
+		{
+			str:      "foo",
+			expected: true,
+		},
+		{
+			str:      "12root",
+			expected: true,
+		},
+		{
+			str:      "0",
+			expected: true,
+		},
+		{
+			str:      "",
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		if a, e := IsPotentialRootUser(test.str), test.expected; a != e {
+			t.Errorf("Unexpected result for %q: %v", test.str, a)
+		}
+	}
+}
+
+func TestIncludesRootUserDirective(t *testing.T) {
+	tests := []struct {
+		cmds     []string
+		expected bool
+	}{
+		{
+			cmds:     []string{"COPY test.file test.dest", "RUN script.sh", "VOLUME test test/data"},
+			expected: false,
+		},
+		{
+			cmds:     []string{"COPY test.file test.dest", "RUN script.sh", "USER root"},
+			expected: true,
+		},
+		{
+			cmds:     []string{"USER 0", "COPY test.file test.dest", "RUN script.sh"},
+			expected: true,
+		},
+		{
+			cmds:     []string{"USER 100", "COPY test.file test.dest", "RUN script.sh"},
+			expected: false,
+		},
+		{
+			cmds:     []string{"USER\t\t   100", "COPY test.file test.dest", "RUN script.sh"},
+			expected: false,
+		},
+		{
+			cmds:     []string{"USER\t\t   0", "COPY test.file test.dest", "RUN script.sh"},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		if a, e := IncludesRootUserDirective(test.cmds), test.expected; a != e {
+			t.Errorf("Unexpected result for %#v: %v", test.cmds, a)
+		}
+	}
+}


### PR DESCRIPTION
If the --no-root flag is specified, the build will fail if the builder does not specify a USER with a numeric id that is not 0.