### PR TITLE
Print builder image labels

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -214,7 +214,7 @@ func newCmdRebuild(cfg *api.Config) *cobra.Command {
 			err := build.GenerateConfigFromLabels(cfg.Tag, cfg)
 			checkErr(err)
 
-			if len(args) >= 1 {
+			if len(args) >= 2 {
 				cfg.Tag = args[1]
 			}
 

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/build"
 )
 
 // Config returns the Config object in nice readable, tabbed format.
@@ -20,7 +21,7 @@ func DescribeConfig(config *api.Config) string {
 		if len(config.Description) > 0 {
 			fmt.Fprintf(out, "Description:\t%s\n", config.Description)
 		}
-		fmt.Fprintf(out, "Builder Image:\t%s\n", config.BuilderImage)
+		describeBuilderImage(config, config.BuilderImage, out)
 		fmt.Fprintf(out, "Source:\t%s\n", config.Source)
 		if len(config.Ref) > 0 {
 			fmt.Fprintf(out, "Source Ref:\t%s\n", config.Ref)
@@ -62,6 +63,27 @@ func DescribeConfig(config *api.Config) string {
 		fmt.Printf("ERROR: %v", err)
 	}
 	return out
+}
+
+func describeBuilderImage(config *api.Config, image string, out io.Writer) {
+	c := &api.Config{
+		DockerConfig:       config.DockerConfig,
+		PullAuthentication: config.PullAuthentication,
+		BuilderImage:       config.BuilderImage,
+		ForcePull:          config.ForcePull,
+		Tag:                config.Tag,
+	}
+	build.GenerateConfigFromLabels(image, c)
+	if len(c.DisplayName) > 0 {
+		fmt.Fprintf(out, "Builder Name:\t%s\n", c.DisplayName)
+	}
+	fmt.Fprintf(out, "Builder Image:\t%s\n", config.BuilderImage)
+	if len(c.BuilderImageVersion) > 0 {
+		fmt.Fprintf(out, "Builder Image Version:\t%s\n", c.BuilderImageVersion)
+	}
+	if len(c.BuilderBaseImageVersion) > 0 {
+		fmt.Fprintf(out, "Builder Base Version:\t%s\n", c.BuilderBaseImageVersion)
+	}
 }
 
 func printEnv(out io.Writer, env map[string]string) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -20,6 +20,12 @@ type Config struct {
 	// BuilderImage describes which image is used for building the result images.
 	BuilderImage string
 
+	// BuilderImageVersion provides optional version information about the builder image.
+	BuilderImageVersion string
+
+	// BuilderBaseImageVersion provides optional version information about the builder base image.
+	BuilderBaseImageVersion string
+
 	// DockerConfig describes how to access host docker daemon.
 	DockerConfig *DockerConfig
 


### PR DESCRIPTION
@bparees @soltysh this patch will display following information about builder (if the labels are set):

```console
Application Name:	testapp
Description:		Platform for building and running Ruby 2.0 applications
Builder Name:		Ruby 2.0
Builder Image:		openshift/ruby-20-centos7
Builder Image Version:	00aa786
Builder Base Version:	edab803
Source:			file:///home/mfojtik/sandbox/ruby
Source Ref:		master-foo
Output Image Tag:	testapp
Incremental Build:	enabled
Remove Old Build:	disabled
Force Pull:		disabled
Quiet:			disabled
Layered Build:		disabled
STI Scripts URL:	image:///usr/local/sti
Docker Endpoint:	unix:///var/run/docker.sock
Docker Pull Config:	/home/mfojtik/.dockercfg
Docker Pull User:	mfojtik
```