### PR TITLE
Remove empty line at the top of the generated scripts

### DIFF
--- a/pkg/create/templates/scripts.go
+++ b/pkg/create/templates/scripts.go
@@ -1,7 +1,6 @@
 package templates
 
-const AssembleScript = `
-#!/bin/bash -e
+const AssembleScript = `#!/bin/bash -e
 #
 # S2I assemble script for the '{{.ImageName}}' image.
 # The 'assemble' script builds your application source ready to run.
@@ -30,8 +29,7 @@ echo "---> Building application from source"
 # TODO: Add build steps for your application, eg npm install, bundle install
 `
 
-const RunScript = `
-#!/bin/bash -e
+const RunScript = `#!/bin/bash -e
 #
 # S2I run script for the '{{.ImageName}}' image.
 # The run script executes the server that runs your application.
@@ -43,8 +41,7 @@ const RunScript = `
 exec <start your server here>
 `
 
-const UsageScript = `
-#!/bin/bash -e
+const UsageScript = `#!/bin/bash -e
 cat <<EOF
 This is the {{.ImageName}} S2I image:
 To use it, install S2I: https://github.com/openshift/source-to-image
@@ -58,8 +55,7 @@ docker run <application image>
 EOF
 `
 
-const SaveArtifactsScript = `
-#!/bin/sh -e
+const SaveArtifactsScript = `#!/bin/sh -e
 #
 # S2I save-artifacts script for the '{{.ImageName}}' image.
 # The save-artifacts script streams a tar archive to standard output.


### PR DESCRIPTION
Otherwise, when running the image with "docker run ...", we have an error :
    Cannot start container [...]: exec format error

Because docker "looks at the first few bytes to determine the type of the file"

See https://github.com/docker/docker/issues/10668 for more