### PR TITLE
Add allowed-uids flag to the sti command

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -188,6 +188,7 @@ func newCmdBuild(cfg *api.Config) *cobra.Command {
 	buildCmd.Flags().StringVarP(&(cfg.EnvironmentFile), "environment-file", "E", "", "Specify the path to the file with environment")
 	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
+	buildCmd.Flags().VarP(&(cfg.AllowedUIDs), "allowed-uids", "u", "Specify a range of allowed user ids for the builder image. If the builder specifies a non-numeric user or a uid that falls outside the range, the build fails.")
 
 	return buildCmd
 }

--- a/hack/build-test-images.sh
+++ b/hack/build-test-images.sh
@@ -28,3 +28,6 @@ buildimage sti_test/sti-fake-scripts test/integration/images/sti-fake-scripts
 buildimage sti_test/sti-fake-scripts-no-save-artifacts test/integration/images/sti-fake-scripts-no-save-artifacts
 buildimage sti_test/sti-fake-no-tar test/integration/images/sti-fake-no-tar
 buildimage sti_test/sti-fake-onbuild test/integration/images/sti-fake-onbuild
+buildimage sti_test/sti-fake-numericuser test/integration/images/sti-fake-numericuser
+buildimage sti_test/sti-fake-onbuild-rootuser test/integration/images/sti-fake-onbuild-rootuser
+buildimage sti_test/sti-fake-onbuild-numericuser test/integration/images/sti-fake-onbuild-numericuser

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -17,7 +17,7 @@ set +e
 img_count=$(docker images | grep -c sti_test/sti-fake)
 set -e
 
-if [ "${img_count}" != "7" ]; then
+if [ "${img_count}" != "10" ]; then
     echo "You do not have necessary test images, be sure to run 'hack/build-test-images.sh' beforehand."
     exit 1
 fi

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,7 +1,12 @@
 package api
 
-import docker "github.com/fsouza/go-dockerclient"
+import (
+	docker "github.com/fsouza/go-dockerclient"
 
+	"github.com/openshift/source-to-image/pkg/util/user"
+)
+
+// Image label namespace constants
 const (
 	DefaultNamespace    = "io.openshift.s2i."
 	KubernetesNamespace = "io.k8s."
@@ -91,6 +96,11 @@ type Config struct {
 	// Specify a relative directory inside the application repository that should
 	// be used as a root directory for the application.
 	ContextDir string
+
+	// AllowedUIDs is a list of user ranges of users allowed to run the builder image.
+	// If a range is specified and the builder image uses a non-numeric user or a user
+	// that is outside the specified range, then the build fails.
+	AllowedUIDs user.RangeList
 }
 
 // DockerConfig contains the configuration for a Docker connection

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -319,7 +319,7 @@ func TestPostExecute(t *testing.T) {
 		}
 		// Ensure Callback was called
 		if ci.CallbackURL != bh.config.CallbackURL {
-			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %", i, bh.config.CallbackURL, ci.CallbackURL)
+			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %s", i, bh.config.CallbackURL, ci.CallbackURL)
 		}
 	}
 }

--- a/pkg/build/strategies/strategies_test.go
+++ b/pkg/build/strategies/strategies_test.go
@@ -1,0 +1,101 @@
+package strategies
+
+import (
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/test"
+	"github.com/openshift/source-to-image/pkg/util/user"
+)
+
+func rangeList(str string) *user.RangeList {
+	l, err := user.ParseRangeList(str)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
+func TestCheckAllowedUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedUIDs *user.RangeList
+		user        string
+		onbuild     []string
+		expectErr   bool
+	}{
+		{
+			name:        "AllowedUIDs is not set",
+			allowedUIDs: rangeList(""),
+			user:        "root",
+			onbuild:     []string{},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, non-numeric user",
+			allowedUIDs: rangeList("0"),
+			user:        "default",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "0",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, non-numeric onbuild",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "100",
+			onbuild:     []string{"COPY test test", "USER default"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, no onbuild user directive",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "200",
+			onbuild:     []string{"VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive",
+			allowedUIDs: rangeList("200,500-"),
+			user:        "200",
+			onbuild:     []string{"USER 500", "VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER 0"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive, upper bound range",
+			allowedUIDs: rangeList("-1000"),
+			user:        "80",
+			onbuild:     []string{"USER 501", "VOLUME /data"},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		cfg := &api.Config{
+			AllowedUIDs: *tc.allowedUIDs,
+		}
+		docker := &test.FakeDocker{
+			GetImageUserResult: tc.user,
+			OnBuildResult:      tc.onbuild,
+		}
+		err := checkAllowedUser(docker, cfg, len(tc.onbuild) > 0)
+		if err != nil && !tc.expectErr {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s: expected error, but did not get any", tc.name)
+		}
+	}
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -47,6 +47,7 @@ const (
 type Docker interface {
 	IsImageInLocalRegistry(name string) (bool, error)
 	IsImageOnBuild(string) bool
+	GetOnBuild(string) ([]string, error)
 	RemoveContainer(id string) error
 	GetScriptsURL(name string) (string, error)
 	RunContainer(opts RunContainerOptions) error
@@ -176,12 +177,19 @@ func (d *stiDocker) GetImageUser(name string) (string, error) {
 // IsImageOnBuild provides information about whether the Docker image has
 // OnBuild instruction recorded in the Image Config.
 func (d *stiDocker) IsImageOnBuild(name string) bool {
+	onbuild, err := d.GetOnBuild(name)
+	return err == nil && len(onbuild) > 0
+}
+
+// GetOnBuild returns the set of ONBUILD Dockerfile commands to execute
+// for the given image
+func (d *stiDocker) GetOnBuild(name string) ([]string, error) {
 	name = getImageName(name)
 	image, err := d.client.InspectImage(name)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	return len(image.Config.OnBuild) > 0
+	return image.Config.OnBuild, nil
 }
 
 // CheckAndPullImage pulls an image into the local registry if not present

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -20,6 +20,7 @@ const (
 	URLHandlerError
 	STIContainerError
 	SourcePathError
+	BuilderUserNotAllowedError
 )
 
 // Error represents an error thrown during STI execution
@@ -202,5 +203,22 @@ func NewSourcePathError(path string) error {
 		Details:    nil,
 		ErrorCode:  SourcePathError,
 		Suggestion: "check the source code path on the local filesystem",
+	}
+}
+
+// NewBuilderUserNotAllowedError returns a new error that indicates that the build
+// could not run because the builder is not allowed to specify a user outside of the
+// range of allowed users
+func NewBuilderUserNotAllowedError(image string, onbuild bool) error {
+	var msg string
+	if onbuild {
+		msg = fmt.Sprintf("image %q includes at least one ONBUILD instruction that sets the user to a user that is not allowed", image)
+	} else {
+		msg = fmt.Sprintf("image %q must specify a user that is numeric and within the range of allowed users", image)
+	}
+	return Error{
+		Message:    msg,
+		ErrorCode:  BuilderUserNotAllowedError,
+		Suggestion: "modify builder image to use a numeric user within the allowed range or build without the --allowed-uids flag",
 	}
 }

--- a/pkg/test/docker.go
+++ b/pkg/test/docker.go
@@ -38,6 +38,11 @@ type FakeDocker struct {
 	BuildImageError              error
 	PullResult                   bool
 	PullError                    error
+	OnBuildImage                 string
+	OnBuildResult                []string
+	OnBuildError                 error
+	IsOnBuildResult              bool
+	IsOnBuildImage               string
 
 	mutex sync.Mutex
 }
@@ -48,8 +53,16 @@ func (f *FakeDocker) IsImageInLocalRegistry(imageName string) (bool, error) {
 	return f.LocalRegistryResult, f.LocalRegistryError
 }
 
+// IsImageOnBuild  returns true if the builder has onbuild instructions
 func (f *FakeDocker) IsImageOnBuild(imageName string) bool {
-	return false
+	f.IsOnBuildImage = imageName
+	return f.IsOnBuildResult
+}
+
+// GetOnBuild returns the list of onbuild instructions for the given image
+func (f *FakeDocker) GetOnBuild(imageName string) ([]string, error) {
+	f.OnBuildImage = imageName
+	return f.OnBuildResult, f.OnBuildError
 }
 
 // RemoveContainer removes a fake Docker container
@@ -115,7 +128,6 @@ func (f *FakeDocker) PullImage(imageName string) (*dockerclient.Image, error) {
 	if f.PullResult {
 		return &dockerclient.Image{}, nil
 	}
-
 	return nil, f.PullError
 }
 

--- a/pkg/util/user/range.go
+++ b/pkg/util/user/range.go
@@ -1,0 +1,169 @@
+package user
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Range errors
+var (
+	ErrInvalidRange = errors.New("invalid range; a range must consist of positive integers and the upper bound must be greater than or equal to the lower bound")
+)
+
+// ErrParseRange is an error encountered while parsing a Range
+type ErrParseRange struct {
+	cause error
+}
+
+func (e *ErrParseRange) Error() string {
+	msg := "error parsing range; a range must be of one of the following formats: [n], [-n], [n-], [n:m] where n and m are positive numbers and m is greater than or equal to n"
+	if e.cause != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.cause)
+	}
+	return msg
+}
+
+// Range represents a range of user ids. It can be unbound at either end with a nil value
+// I both From and To are present, To must be greater than or equal to From. Bounds are inclusive
+type Range struct {
+	from *int
+	to   *int
+}
+
+// NewRange creates a new range with lower and upper bound
+func NewRange(from int, to int) (*Range, error) {
+	return (&rangeBuilder{}).from(from, nil).to(to, nil).Range()
+}
+
+// NewRangeTo creates a new range with only the upper bound
+func NewRangeTo(to int) (*Range, error) {
+	return (&rangeBuilder{}).to(to, nil).Range()
+}
+
+// NewRangeFrom creates a new range with only the lower bound
+func NewRangeFrom(from int) (*Range, error) {
+	return (&rangeBuilder{}).from(from, nil).Range()
+}
+
+func parseInt(str string) (int, error) {
+	num, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, &ErrParseRange{cause: err}
+	}
+	return num, nil
+}
+
+type rangeBuilder struct {
+	r   Range
+	err error
+}
+
+func (b *rangeBuilder) from(num int, err error) *rangeBuilder {
+	return b.setBound(num, err, &b.r.from)
+}
+
+func (b *rangeBuilder) to(num int, err error) *rangeBuilder {
+	return b.setBound(num, err, &b.r.to)
+}
+
+func (b *rangeBuilder) setBound(num int, err error, bound **int) *rangeBuilder {
+	if b.err != nil {
+		return b
+	}
+	if b.err = err; b.err != nil {
+		return b
+	}
+	if num < 0 {
+		b.err = ErrInvalidRange
+		return b
+	}
+	*bound = &num
+	return b
+}
+
+func (b *rangeBuilder) Range() (*Range, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if b.r.from != nil && b.r.to != nil && *b.r.to < *b.r.from {
+		return nil, ErrInvalidRange
+	}
+	return &b.r, nil
+}
+
+// ParseRange creates a Range from a given string
+func ParseRange(value string) (*Range, error) {
+	value = strings.TrimSpace(value)
+	b := &rangeBuilder{}
+	if value == "" {
+		return b.Range()
+	}
+	parts := strings.Split(value, "-")
+	switch len(parts) {
+	case 1:
+		num, err := parseInt(parts[0])
+		return b.from(num, err).to(num, err).Range()
+	case 2:
+		if parts[0] != "" {
+			b.from(parseInt(parts[0]))
+		}
+		if parts[1] != "" {
+			b.to(parseInt(parts[1]))
+		}
+		return b.Range()
+	default:
+		return nil, &ErrParseRange{}
+	}
+}
+
+// Contains returns true if the argument falls inside the Range
+func (r *Range) Contains(value int) bool {
+	if r.from == nil && r.to == nil {
+		return false
+	}
+	if r.from != nil && value < *r.from {
+		return false
+	}
+	if r.to != nil && value > *r.to {
+		return false
+	}
+	return true
+}
+
+// String returns a parse-able string representation of a Range
+func (r *Range) String() string {
+	switch {
+	case r.from == nil && r.to == nil:
+		return ""
+	case r.from == nil:
+		return fmt.Sprintf("-%d", *r.to)
+	case r.to == nil:
+		return fmt.Sprintf("%d-", *r.from)
+	case *r.from == *r.to:
+		return fmt.Sprintf("%d", *r.to)
+	default:
+		return fmt.Sprintf("%d-%d", *r.from, *r.to)
+	}
+}
+
+// Type returns the type of a Range object
+func (r *Range) Type() string {
+	return "user.Range"
+}
+
+// Set sets the value of a Range object
+func (r *Range) Set(value string) error {
+	newRange, err := ParseRange(value)
+	if err != nil {
+		return err
+	}
+	*r = *newRange
+	return nil
+}
+
+// Empty returns true if the range has no bounds
+func (r *Range) Empty() bool {
+	return r.from == nil && r.to == nil
+}

--- a/pkg/util/user/range_test.go
+++ b/pkg/util/user/range_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"testing"
+)
+
+func validRange(r *Range, err error) *Range {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func TestParseRange(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *Range
+		errExpected bool
+	}{
+		{
+			str:      "1-5",
+			expected: validRange(NewRange(1, 5)),
+		},
+		{
+			str:      "7",
+			expected: validRange(NewRange(7, 7)),
+		},
+		{
+			str:      "1-",
+			expected: validRange(NewRangeFrom(1)),
+		},
+		{
+			str:      "-1000",
+			expected: validRange(NewRangeTo(1000)),
+		},
+		{
+			str:      "",
+			expected: &Range{},
+		},
+		{
+			str:         "--",
+			errExpected: true,
+		},
+		{
+			str:         "4-5-1",
+			errExpected: true,
+		},
+		{
+			str:         "-1-5",
+			errExpected: true,
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+	}
+	for _, tc := range tests {
+		actual, err := ParseRange(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Did not get expected error for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range for input %s. Expected: %v. Got: %v", tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *Range
+		expected bool
+	}{
+		{
+			uid:      0,
+			r:        validRange(NewRange(0, 4)),
+			expected: true,
+		},
+		{
+			uid:      0,
+			r:        validRange(NewRangeFrom(1)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(5001)),
+			expected: true,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(4999)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &Range{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/util/user/rangelist.go
+++ b/pkg/util/user/rangelist.go
@@ -1,0 +1,102 @@
+package user
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// RangeList is a list of user ranges
+type RangeList []*Range
+
+// ParseRangeList parses a string that contains a comma-separated list of ranges
+func ParseRangeList(str string) (*RangeList, error) {
+	rl := RangeList{}
+	if len(str) == 0 {
+		return &rl, nil
+	}
+	parts := strings.Split(str, ",")
+	for _, p := range parts {
+		r, err := ParseRange(p)
+		if err != nil {
+			return nil, err
+		}
+		rl = append(rl, r)
+	}
+	return &rl, nil
+}
+
+// Empty returns true if the RangeList is empty
+func (l *RangeList) Empty() bool {
+	if len(*l) == 0 {
+		return true
+	}
+	for _, r := range *l {
+		if !r.Empty() {
+			return false
+		}
+	}
+	return true
+}
+
+// Contains returns true if the uid is contained by any range in the RangeList
+func (l *RangeList) Contains(uid int) bool {
+	for _, r := range *l {
+		if r.Contains(uid) {
+			return true
+		}
+	}
+	return false
+}
+
+// Type returns the type of a RangeList object
+func (l *RangeList) Type() string {
+	return "user.RangeList"
+}
+
+// Set sets the value of a RangeList object
+func (l *RangeList) Set(value string) error {
+	newRangeList, err := ParseRangeList(value)
+	if err != nil {
+		return err
+	}
+	*l = *newRangeList
+	return nil
+}
+
+// String returns a parseable string representation of a RangeList
+func (l *RangeList) String() string {
+	rangeStrings := []string{}
+	for _, r := range *l {
+		rangeStrings = append(rangeStrings, r.String())
+	}
+	return strings.Join(rangeStrings, ",")
+}
+
+// IsUserAllowed checks that the given user is numeric and is
+// contained by the given RangeList
+func IsUserAllowed(user string, allowed *RangeList) bool {
+	uid, err := strconv.Atoi(user)
+	if err != nil {
+		return false
+	}
+	return allowed.Contains(uid)
+}
+
+var dockerLineDelim = regexp.MustCompile(`[\t\v\f\r ]+`)
+
+// IsOnbuildAllowed checks a list of Docker ONBUILD instructions for
+// user directives. It ensures that any users specified by the directives
+// falls within the specified range list of users.
+func IsOnbuildAllowed(directives []string, allowed *RangeList) bool {
+	for _, line := range directives {
+		parts := dockerLineDelim.Split(line, 2)
+		if strings.ToLower(parts[0]) != "user" {
+			continue
+		}
+		if !IsUserAllowed(parts[1], allowed) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/user/rangelist_test.go
+++ b/pkg/util/user/rangelist_test.go
@@ -1,0 +1,123 @@
+package user
+
+import (
+	"testing"
+)
+
+func TestParseRangeList(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *RangeList
+		errExpected bool
+	}{
+		{
+			str: "1-5,5,2-",
+			expected: &RangeList{
+				validRange(NewRange(1, 5)),
+				validRange(NewRange(5, 5)),
+				validRange(NewRangeFrom(2)),
+			},
+		},
+		{
+			str: ",4-5,0-",
+			expected: &RangeList{
+				&Range{},
+				validRange(NewRange(4, 5)),
+				validRange(NewRangeFrom(0)),
+			},
+		},
+		{
+			str: "5",
+			expected: &RangeList{
+				validRange(NewRange(5, 5)),
+			},
+		},
+		{
+			str: "1-",
+			expected: &RangeList{
+				validRange(NewRangeFrom(1)),
+			},
+		},
+		{
+			str: "-5",
+			expected: &RangeList{
+				validRange(NewRangeTo(5)),
+			},
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+		{
+			str:         "{1-5}",
+			errExpected: true,
+		},
+		{
+			str:         "1-5-,2-",
+			errExpected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := ParseRangeList(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Expected error but did not get one for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range list for input %s. Expected: %v, Got: %v",
+				tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestRangeListContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *RangeList
+		expected bool
+	}{
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRange(0, 9)),
+				validRange(NewRange(10, 10)),
+				validRange(NewRange(20, 30)),
+			},
+			expected: true,
+		},
+		{
+			uid: 5,
+			r: &RangeList{
+				validRange(NewRange(3, 4)),
+				validRange(NewRange(6, 7)),
+			},
+			expected: false,
+		},
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRangeFrom(11)),
+				validRange(NewRangeFrom(20)),
+			},
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &RangeList{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/test/integration/images/sti-fake-numericuser/Dockerfile
+++ b/test/integration/images/sti-fake-numericuser/Dockerfile
@@ -1,0 +1,10 @@
+#
+# This is fake image used for testing STI. It tests running build as a numeric user
+#
+FROM sti_test/sti-fake
+
+RUN mkdir -p /sti-fake && \
+    adduser -u 431 -h /sti-fake -s /sbin/nologin -D fakeuser && \
+    chown -R fakeuser /sti-fake
+
+USER 431

--- a/test/integration/images/sti-fake-onbuild-numericuser/Dockerfile
+++ b/test/integration/images/sti-fake-onbuild-numericuser/Dockerfile
@@ -1,0 +1,14 @@
+FROM sti_test/sti-fake
+
+USER 1001
+
+ONBUILD USER 1001
+ONBUILD RUN touch /tmp/onbuild
+
+# The ONBUILD strategy only works with the application source dir so we need
+# to manually specify to copy to another location.
+#
+# This is a little hack-ish given that we know our assemble script requires files to be in /tmp/src
+# we will copy there, and also set our WORKDIR to be the same location so it has access to the scripts
+ONBUILD COPY . /tmp/src/
+WORKDIR /tmp/src

--- a/test/integration/images/sti-fake-onbuild-rootuser/Dockerfile
+++ b/test/integration/images/sti-fake-onbuild-rootuser/Dockerfile
@@ -1,0 +1,12 @@
+FROM sti_test/sti-fake
+
+ONBUILD USER 0
+ONBUILD RUN touch /tmp/onbuild
+
+# The ONBUILD strategy only works with the application source dir so we need
+# to manually specify to copy to another location.
+#
+# This is a little hack-ish given that we know our assemble script requires files to be in /tmp/src
+# we will copy there, and also set our WORKDIR to be the same location so it has access to the scripts
+ONBUILD COPY . /tmp/src/
+WORKDIR /tmp/src


### PR DESCRIPTION
Adds a flag --allowed-uids to the sti command that takes a comma-separated list of uid ranges, where a range can be:
1) a single number
2) [from]-[to] where [from] and [to] are integers
3) [from]-  a range with no upper bound
4) -[to]  a range with no lower bound

If this argument is specified, S2I checks whether the user specified in the builder image is 
1) numeric
2) is contained within the specified ranges
(For ONBUILD images the check also applies to USER ONBUILD instructions)

If those conditions are not met, the build fails. 