### PR TITLE
Adding context-dir to SourceInfo object

### DIFF
--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -53,6 +53,10 @@ func (c *Clone) Download(config *api.Config) (*api.SourceInfo, error) {
 			info = c.GetInfo(targetSourceDir)
 		}
 
+		if len(config.ContextDir) > 0 {
+			info.ContextDir = config.ContextDir
+		}
+
 		return info, nil
 	}
 	// we want to copy entire dir contents, thus we need to use dir/. construct


### PR DESCRIPTION
Found our that the SourceInfo.ContextDir field is not filled by the ContextDir from the Config.

@bparees PTAL