### PR TITLE
always pull if not present for incremental

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -286,7 +286,7 @@ func (b *STI) Exists(config *api.Config) bool {
 
 	// can only do incremental build if runtime image exists, so always pull image
 	previousImageExists, _ := b.docker.IsImageInLocalRegistry(config.Tag)
-	if config.ForcePull {
+	if !previousImageExists || config.ForcePull {
 		if image, _ := b.docker.PullImage(config.Tag); image != nil {
 			previousImageExists = true
 		}


### PR DESCRIPTION
addresses another part of https://github.com/openshift/origin/issues/4127

@jhadvig @soltysh @mfojtik @gabemontero ptal.

I debated just always pulling the previous image, period.  That would avoid the possibility that someone does an incremental build with a stale previous image and picks up bad dependencies/artifacts, but in the end i decided we have "forcePull" for a reason, so the semantics are:

if forcePull is true, the builder AND the previous image (if incremental) are pulled.
if forcePull is false and the previous image does not exist locally, it is pulled.  
if forcePull is false and the previous image does exist, it is used (might be stale)
