### PR TITLE
Improve log messages for incremental build

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -115,10 +115,12 @@ func (b *STI) Build(config *api.Config) (*api.Result, error) {
 		return nil, err
 	}
 
-	if b.incremental = b.artifacts.Exists(config); b.incremental {
-		glog.V(1).Infof("Existing image for tag %s detected for incremental build", config.Tag)
+	if !config.Incremental {
+		glog.V(1).Infof("Incremental build is disabled. Clean build will be performed")
+	} else if b.incremental = b.artifacts.Exists(config); b.incremental {
+		glog.V(1).Infof("Existing image for tag %s detected. Perform Incremental build with save-artifacts under the %s", config.Tag, b.scriptsURL["save-artifacts"])
 	} else {
-		glog.V(1).Infof("Clean build will be performed")
+		glog.V(1).Infof("Incremental build is enabled. But existing image for tag %s was not detected. Clean build will be performed", config.Tag)
 	}
 
 	glog.V(2).Infof("Performing source build from %s", config.Source)
@@ -272,13 +274,8 @@ func (b *STI) PostExecute(containerID, location string) error {
 }
 
 // Exists determines if the current build supports incremental workflow.
-// It checks if the previous image exists in the system and if so, then it
-// verifies that the save-artifacts script is present.
+// It checks if the previous image exists in the system.
 func (b *STI) Exists(config *api.Config) bool {
-	if !config.Incremental {
-		return false
-	}
-
 	// can only do incremental build if runtime image exists, so always pull image
 	previousImageExists, _ := b.docker.IsImageInLocalRegistry(config.Tag)
 	if !previousImageExists || config.ForcePull {
@@ -287,7 +284,7 @@ func (b *STI) Exists(config *api.Config) bool {
 		}
 	}
 
-	return previousImageExists && b.installedScripts[api.SaveArtifacts]
+	return previousImageExists
 }
 
 // Save extracts and restores the build artifacts from the previous build to a


### PR DESCRIPTION
This PR contains following changes:

- L#290[1]: Remove `b.installedScripts[api.SaveArtifacts]`, since it is 99.9% true. Alternatively add message `build with save-artifacts under the %s", config.Tag, b.scriptsURL["save-artifacts"]`.
- L#278[2]: Move incremental build check in `func Exists()`.

[1] https://github.com/openshift/source-to-image/blob/4902844a6fc2c6869cdf7cc8ca9f269628c1ef4e/pkg/build/strategies/sti/sti.go#L290
[2] https://github.com/openshift/source-to-image/blob/4902844a6fc2c6869cdf7cc8ca9f269628c1ef4e/pkg/build/strategies/sti/sti.go#L278