### PR TITLE
fix syntax error: unexpected range for go1.3.3

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -404,8 +404,8 @@ func runContainerDockerRun(container *docker.Container, d *stiDocker, image stri
 	cleanupDone := make(chan bool)
 	signal.Notify(signalChan, os.Interrupt)
 	go func() {
-		for _ = range signalChan {
-			glog.V(2).Info("\nReceived an interrupt, stopping services...\n")
+		for signal := range signalChan {
+			glog.V(2).Info("\nReceived signal %s, stopping services...\n", signal)
 			cleanupDone <- true
 		}
 	}()

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -404,7 +404,7 @@ func runContainerDockerRun(container *docker.Container, d *stiDocker, image stri
 	cleanupDone := make(chan bool)
 	signal.Notify(signalChan, os.Interrupt)
 	go func() {
-		for range signalChan {
+		for _ = range signalChan {
 			glog.V(2).Info("\nReceived an interrupt, stopping services...\n")
 			cleanupDone <- true
 		}


### PR DESCRIPTION
when go version is 1.3.3, compile with error:
[root@openshift-144 source-to-image]# make
hack/build-go.sh
++ Building go targets for linux/amd64: cmd/sti
github.com/openshift/source-to-image/pkg/docker
_output/local/go/src/github.com/openshift/source-to-image/pkg/docker/docker.go:407: syntax error: unexpected range, expecting {
_output/local/go/src/github.com/openshift/source-to-image/pkg/docker/docker.go:410: syntax error: argument to go/defer must be function call
_output/local/go/src/github.com/openshift/source-to-image/pkg/docker/docker.go:412: non-declaration statement outside function body
_output/local/go/src/github.com/openshift/source-to-image/pkg/docker/docker.go:413: syntax error: unexpected }