### PR TITLE
Allow to disable --recursive fetch

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -187,6 +187,7 @@ func newCmdBuild(cfg *api.Config) *cobra.Command {
 	buildCmd.Flags().BoolVarP(&(cfg.Quiet), "quiet", "q", false, "Operate quietly. Suppress all non-error output.")
 	buildCmd.Flags().BoolVar(&(cfg.RunImage), "run", false, "Run resulting image as part of invocation of this command.  You may have to Ctrl-C to exit the sti command invocation and the container launched because this options was specified.")
 	buildCmd.Flags().BoolVar(&(cfg.Incremental), "incremental", false, "Perform an incremental build")
+	buildCmd.Flags().BoolVar(&(cfg.DisableRecursive), "recursive", true, "Fetch all git submodules when cloning application repository")
 	buildCmd.Flags().BoolVar(&(cfg.RemovePreviousImage), "rm", false, "Remove the previous image during incremental builds")
 	buildCmd.Flags().StringP("env", "e", "", "Specify an environment var NAME=VALUE,NAME2=VALUE2,...")
 	buildCmd.Flags().StringVarP(&(cfg.Ref), "ref", "r", "", "Specify a ref to check-out")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -48,6 +48,10 @@ type Config struct {
 	// PreserveWorkingDir describes if working directory should be left after processing.
 	PreserveWorkingDir bool
 
+	// DisableRecursive disables the --recursive option for the git clone that
+	// allows to use the GIT without requiring the git submodule to be called.
+	DisableRecursive bool
+
 	// Source URL describing the location of sources used to build the result image.
 	Source string
 
@@ -196,4 +200,11 @@ type SourceInfo struct {
 	// The output image will contain this information as 'io.openshift.build.source-context-dir'
 	// label.
 	ContextDir string
+}
+
+// CloneConfig specifies the options used when cloning the application source
+// code.
+type CloneConfig struct {
+	Recursive bool
+	Quiet     bool
 }

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -20,13 +20,18 @@ func (c *Clone) Download(config *api.Config) (*api.SourceInfo, error) {
 	targetSourceDir := filepath.Join(config.WorkingDir, api.Source)
 	config.WorkingSourceDir = targetSourceDir
 	var info *api.SourceInfo
+	cloneConfig := api.CloneConfig{Quiet: true, Recursive: !config.DisableRecursive}
 
 	if c.ValidCloneSpec(config.Source) {
 		if len(config.ContextDir) > 0 {
 			targetSourceDir = filepath.Join(config.WorkingDir, api.ContextTmp)
 		}
-		glog.V(2).Infof("Cloning into %s", targetSourceDir)
-		if err := c.Clone(config.Source, targetSourceDir); err != nil {
+		if cloneConfig.Recursive {
+			glog.V(2).Infof("Cloning sources and all GIT submodules into %q", targetSourceDir)
+		} else {
+			glog.V(2).Infof("Cloning sources into %q", targetSourceDir)
+		}
+		if err := c.Clone(config.Source, targetSourceDir, cloneConfig); err != nil {
 			glog.V(1).Infof("Git clone failed: %+v", err)
 			return nil, err
 		}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/test"
 )
 
@@ -40,7 +41,7 @@ func getGit() (*stiGit, *test.FakeCmdRunner) {
 
 func TestGitClone(t *testing.T) {
 	gh, ch := getGit()
-	err := gh.Clone("source1", "target1")
+	err := gh.Clone("source1", "target1", api.CloneConfig{Quiet: true, Recursive: true})
 	if err != nil {
 		t.Errorf("Unexpected error returned from clone: %v\n", err)
 	}
@@ -56,7 +57,7 @@ func TestGitCloneError(t *testing.T) {
 	gh, ch := getGit()
 	runErr := fmt.Errorf("Run Error")
 	ch.Err = runErr
-	err := gh.Clone("source1", "target1")
+	err := gh.Clone("source1", "target1", api.CloneConfig{})
 	if err != runErr {
 		t.Errorf("Unexpected error returned from clone: %v\n", err)
 	}

--- a/pkg/test/git.go
+++ b/pkg/test/git.go
@@ -1,6 +1,8 @@
 package test
 
-import "github.com/openshift/source-to-image/pkg/api"
+import (
+	"github.com/openshift/source-to-image/pkg/api"
+)
 
 // FakeGit provides a fake GIT
 type FakeGit struct {
@@ -23,7 +25,7 @@ func (f *FakeGit) ValidCloneSpec(source string) bool {
 }
 
 // Clone clones the fake source GIT repository to target directory
-func (f *FakeGit) Clone(source, target string) error {
+func (f *FakeGit) Clone(source, target string, c api.CloneConfig) error {
 	f.CloneSource = source
 	f.CloneTarget = target
 	return f.CloneError


### PR DESCRIPTION
This allows you to set `--recursive=false` to disable `git clone --recursive`.
