### PR TITLE
Use unix-style path separators when creating tar files

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -147,7 +147,7 @@ func (t *stiTar) writeTarHeader(tarWriter *tar.Writer, dir string, path string, 
 	if includeDirInPath {
 		prefix = filepath.Dir(prefix)
 	}
-	header.Name = path[1+len(prefix):]
+	header.Name = filepath.ToSlash(path[1+len(prefix):])
 	glog.V(3).Infof("Adding to tar: %s as %s", path, header.Name)
 	if err = tarWriter.WriteHeader(header); err != nil {
 		return err


### PR DESCRIPTION
When tarring windows paths, we store the windows-style path separators in the tar. If the tar is extracted on a unix system, the separators are not interpreted correctly. However, extracting a tar on a windows machine always works correctly with unix-style path separators.