### PR TITLE
Get the whole commitID hash

### DIFF
--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -131,7 +131,7 @@ func (h *stiGit) GetInfo(repo string) *api.SourceInfo {
 	return &api.SourceInfo{
 		Location: git("config", "--get", "remote.origin.url"),
 		Ref:      git("rev-parse", "--abbrev-ref", "HEAD"),
-		CommitID: git("rev-parse", "--short", "--verify", "HEAD"),
+		CommitID: git("rev-parse", "--verify", "HEAD"),
 		Author:   git("--no-pager", "show", "-s", "--format=%an <%ae>", "HEAD"),
 		Date:     git("--no-pager", "show", "-s", "--format=%ad", "HEAD"),
 		Message:  git("--no-pager", "show", "-s", "--format=%<(80,trunc)%s", "HEAD"),


### PR DESCRIPTION
Get the whole commit ID hash instead of the short version.

Based on conversation at the end of the https://github.com/openshift/origin/issues/615 issue.

@bparees @smarterclayton PTAL