### PR TITLE
WIP: Add docker:// source strategy

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -10,10 +10,11 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 
-	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/errors"
 	"os"
 	"os/signal"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/errors"
 )
 
 const (
@@ -104,6 +105,7 @@ type RunContainerOptions struct {
 	ScriptsURL      string
 	Destination     string
 	Command         string
+	Cmd             []string
 	Env             []string
 	Stdin           io.Reader
 	Stdout          io.Writer
@@ -504,6 +506,10 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) (err error) {
 	}
 	if opts.Stdout != nil {
 		config.AttachStdout = true
+	}
+
+	if len(opts.Cmd) > 0 {
+		config.Cmd = opts.Cmd
 	}
 
 	glog.V(2).Infof("Creating container using config: %+v", config)

--- a/pkg/scm/docker/copy.go
+++ b/pkg/scm/docker/copy.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+	dockerpkg "github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/scm/file"
+	"github.com/openshift/source-to-image/pkg/tar"
+	"github.com/openshift/source-to-image/pkg/util"
+)
+
+type Docker struct {
+}
+
+func (d *Docker) Download(config *api.Config) (*api.SourceInfo, error) {
+	dockerclient, err := dockerpkg.New(config.DockerConfig, config.PullAuthentication)
+	if err != nil {
+		return nil, err
+	}
+	image, sourcePath := parseDockerSource(config.Source)
+	targetDir := filepath.Join(config.WorkingDir, "upload", "sources")
+
+	if config.ForcePull {
+		if _, err = dockerclient.PullImage(image); err != nil {
+			glog.Warningf("Failed to pull %q (%v), searching for the local image ...", image, err)
+			_, err = dockerclient.CheckImage(image)
+		}
+	} else {
+		_, err = dockerclient.CheckAndPullImage(image)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy the files from the container
+	outReader, outWriter := io.Pipe()
+	errReader, errWriter := io.Pipe()
+	defer errReader.Close()
+	defer errWriter.Close()
+	glog.V(1).Infof("Downloading sources from %q to %q", image, targetDir)
+	extractFunc := func() error {
+		defer outReader.Close()
+		return tar.New().ExtractTarStream(targetDir, outReader)
+	}
+	opts := dockerpkg.RunContainerOptions{
+		Image:       image,
+		ScriptsURL:  config.ScriptsURL,
+		Destination: config.Destination,
+		Cmd:         []string{"tar", "cf", "-", sourcePath},
+		Stdout:      outWriter,
+		Stderr:      errWriter,
+		OnStart:     extractFunc,
+	}
+	go dockerpkg.StreamContainerIO(errReader, nil, glog.Error)
+	err = dockerclient.RunContainer(opts)
+	if e, ok := err.(errors.ContainerError); ok {
+		return nil, fmt.Errorf("Failed to extract sources from %q: %v\n%s\n", image, err, e.Output)
+	}
+
+	config.Source = "file://" + targetDir
+	handler := &file.File{util.NewFileSystem()}
+	return handler.Download(config)
+}
+
+func parseDockerSource(s string) (image string, location string) {
+	s = strings.TrimPrefix(s, "docker://")
+	if !strings.Contains(s, ":") {
+		image = s
+	} else {
+		image = s[0:strings.LastIndex(s, ":")]
+	}
+	if strings.HasPrefix(image, "/") {
+		image = ""
+		return
+	}
+	if strings.LastIndex(s, ":")+1 >= len(s) || !strings.Contains(s, ":") {
+		location = "."
+		return
+	}
+	return image, s[strings.LastIndex(s, ":")+1:]
+}

--- a/pkg/scm/docker/docker_test.go
+++ b/pkg/scm/docker/docker_test.go
@@ -1,0 +1,24 @@
+package docker
+
+import "testing"
+
+func TestParseDockerSource(t *testing.T) {
+	table := map[string][]string{
+		"docker://foo/bar":                  {"foo/bar", "."},
+		"docker://foo/bar:":                 {"foo/bar", "."},
+		"openshift/ruby-20-centos:/tmp/dir": {"openshift/ruby-20-centos", "/tmp/dir"},
+		"docker://openshift/app-image:/":    {"openshift/app-image", "/"},
+		"docker://openshift/app-image:.":    {"openshift/app-image", "."},
+		"docker://openshift/app-image:":     {"openshift/app-image", "."},
+		"docker:///bar":                     {"", ""},
+	}
+	for source, result := range table {
+		image, location := parseDockerSource(source)
+		if image != result[0] {
+			t.Errorf("Expected %q to return image name %q, got %q", source, result[0], image)
+		}
+		if location != result[1] {
+			t.Errorf("Expected %q to return location %q, got %q", source, result[1], location)
+		}
+	}
+}

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/openshift/source-to-image/pkg/build"
+	"github.com/openshift/source-to-image/pkg/scm/docker"
 	"github.com/openshift/source-to-image/pkg/scm/file"
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/util"
@@ -16,6 +17,9 @@ import (
 // DownloaderForSource determines what SCM plugin should be used for downloading
 // the sources from the repository.
 func DownloaderForSource(s string) (build.Downloader, string, error) {
+	if strings.HasPrefix(s, "docker://") {
+		return &docker.Docker{}, s, nil
+	}
 	// If the source is using file:// protocol but it is not a GIT repository,
 	// trim the prefix and treat it as a file copy.
 	if strings.HasPrefix(s, "file://") && !isLocalGitRepository(s) {


### PR DESCRIPTION
This will allow to specify the source location that points into a directory inside Docker image. For example:

```console
$ s2i build docker://sample-app-sources:/sample-app openshift/ruby-20-centos7 final-app
```

In this case, we will pull (or not pull as force-pull applies here) the `sample-app-sources` Docker image, then run it and stream the `/sample-app` directory using `tar`. Once we have this directory locally, we just set the source location to "file://local-folder" and execute the regular S2I build.

The output looks like this (in this example the `sample-app-sources` is just a busybox image with sources ADD to `/sample-app`:

```console
I1009 13:39:31.884721 28057 util.go:31] Getting docker credentials for openshift/ruby-20-centos7
I1009 13:39:31.884855 28057 util.go:43] Using mi@mifo.sk credentials for pulling openshift/ruby-20-centos7
I1009 13:39:31.890272 28057 docker.go:214] Image openshift/ruby-20-centos7:latest available locally

Builder Name:		Ruby 2.0
Builder Image:		openshift/ruby-20-centos7
Builder Image Version:	004e164
Builder Base Version:	71a650e
Source:			docker://sample-app-sources:/sample-app
Output Image Tag:	final-app
Incremental Build:	disabled
Remove Old Build:	disabled
Force Pull:		disabled
Quiet:			disabled
Layered Build:		disabled
Docker Endpoint:	unix:///var/run/docker.sock
Docker Pull Config:	/root/.docker/config.json
Docker Pull User:	mfojtik

I1009 13:39:31.891933 28057 docker.go:214] Image openshift/ruby-20-centos7:latest available locally
I1009 13:39:31.892988 28057 sti.go:128] Preparing to build final-app
I1009 13:39:31.893852 28057 docker.go:214] Image sample-app-sources:latest available locally
I1009 13:39:31.893872 28057 copy.go:47] Downloading sources from "sample-app-sources" to "/tmp/sti594925303/upload/sources"
W1009 13:39:31.894670 28057 docker.go:329] Image does not contain a value for the io.openshift.s2i.scripts-url label
I1009 13:39:31.894694 28057 docker.go:384] Base directory for STI scripts is ''. Untarring destination is '/tmp'.
I1009 13:39:31.894703 28057 docker.go:515] Creating container using config: {Hostname: Domainname: User: Memory:0 MemorySwap:0 CPUShares:0 CPUSet: AttachStdin:false AttachStdout:true AttachStderr:false PortSpecs:[] ExposedPorts:map[] Tty:false OpenStdin:false StdinOnce:false Env:[] Cmd:[tar cf - /sample-app] DNS:[] Image:sample-app-sources:latest Volumes:map[] VolumesFrom: WorkingDir: MacAddress: Entrypoint:[] NetworkDisabled:false SecurityOpts:[] OnBuild:[] Mounts:[] Labels:map[]}
I1009 13:39:32.197016 28057 docker.go:526] Attaching to container
I1009 13:39:32.198151 28057 docker.go:532] Starting container
E1009 13:39:32.318124 28057 util.go:85] tar: removing leading '/' from member names

... some noisy tar output ...

I1009 13:39:33.314178 28057 docker.go:331] Image contains io.openshift.s2i.scripts-url set to 'image:///usr/libexec/s2i'
I1009 13:39:33.314194 28057 docker.go:384] Base directory for STI scripts is '/usr/libexec/s2i'. Untarring destination is '/tmp'.
I1009 13:39:33.314202 28057 docker.go:515] Creating container using config: {Hostname: Domainname: User: Memory:0 MemorySwap:0 CPUShares:0 CPUSet: AttachStdin:false AttachStdout:true AttachStderr:false PortSpecs:[] ExposedPorts:map[] Tty:false OpenStdin:true StdinOnce:true Env:[] Cmd:[/bin/sh -c tar -C /tmp -xf - && /usr/libexec/s2i/assemble] DNS:[] Image:openshift/ruby-20-centos7:latest Volumes:map[] VolumesFrom: WorkingDir: MacAddress: Entrypoint:[] NetworkDisabled:false SecurityOpts:[] OnBuild:[] Mounts:[] Labels:map[]}
I1009 13:39:33.649982 28057 docker.go:526] Attaching to container
I1009 13:39:33.650717 28057 docker.go:532] Starting container
I1009 13:39:33.803550 28057 docker.go:462] Waiting for container
I1009 13:39:33.847278 28057 sti.go:430] ---> Installing application source ...
I1009 13:39:33.850295 28057 sti.go:430] ---> Building your Ruby application from source ...
I1009 13:39:33.965133 28057 sti.go:430] WARNING: Rubygem Rack is not installed in the present image.
I1009 13:39:33.965158 28057 sti.go:430]          Add rack to your Gemfile in order to start the web server.
I1009 13:39:34.185579 28057 docker.go:464] Container wait returns with 0 and <nil>
I1009 13:39:34.185600 28057 docker.go:471] Container exited
I1009 13:39:34.185603 28057 docker.go:554] Invoking postExecution function
I1009 13:39:34.185711 28057 sti.go:252] No .sti/environment provided (no environment file found in application sources)
I1009 13:39:34.187576 28057 docker.go:588] Committing container with config: {Hostname: Domainname: User: Memory:0 MemorySwap:0 CPUShares:0 CPUSet: AttachStdin:false AttachStdout:false AttachStderr:false PortSpecs:[] ExposedPorts:map[] Tty:false OpenStdin:false StdinOnce:false Env:[] Cmd:[/usr/libexec/s2i/run] DNS:[] Image: Volumes:map[] VolumesFrom: WorkingDir: MacAddress: Entrypoint:[] NetworkDisabled:false SecurityOpts:[] OnBuild:[] Mounts:[] Labels:map[io.openshift.builder-version:004e164 io.openshift.expose-services:8080:http License:GPLv2 io.openshift.builder-base-version:71a650e io.openshift.s2i.scripts-url:image:///usr/libexec/s2i Vendor:CentOS io.k8s.display-name:final-app io.openshift.s2i.build.image:openshift/ruby-20-centos7 io.openshift.s2i.build.source-location:/tmp/sti594925303/upload/sources io.openshift.tags:builder,ruby,ruby20 io.s2i.scripts-url:image:///usr/libexec/s2i io.k8s.description:Platform for building and running Ruby 2.0 applications]}
I1009 13:39:35.562074 28057 sti.go:288] Successfully built final-app
I1009 13:39:36.485138 28057 cleanup.go:23] Removing temporary directory /tmp/sti594925303
I1009 13:39:36.485160 28057 fs.go:99] Removing directory '/tmp/sti594925303'

```