### PR TITLE
Allow S2I behavior to be overriden by caller

### DIFF
--- a/pkg/build/interfaces.go
+++ b/pkg/build/interfaces.go
@@ -62,3 +62,9 @@ type SourceHandler interface {
 type LayeredDockerBuilder interface {
 	Builder
 }
+
+// Overrides are interfaces that may be passed into build strategies to
+// alter the behavior of a strategy.
+type Overrides struct {
+	Downloader Downloader
+}

--- a/pkg/build/strategies/layered/layered.go
+++ b/pkg/build/strategies/layered/layered.go
@@ -27,7 +27,7 @@ type Layered struct {
 	scripts build.ScriptsHandler
 }
 
-func New(config *api.Config, scripts build.ScriptsHandler) (*Layered, error) {
+func New(config *api.Config, scripts build.ScriptsHandler, overrides build.Overrides) (*Layered, error) {
 	d, err := docker.New(config.DockerConfig, config.PullAuthentication)
 	if err != nil {
 		return nil, err
@@ -82,6 +82,7 @@ func (b *Layered) CreateDockerfile(config *api.Config) error {
 	return nil
 }
 
+// TODO: this should stop generating a file, and instead stream the tar.
 func (b *Layered) SourceTar(config *api.Config) (io.ReadCloser, error) {
 	uploadDir := filepath.Join(config.WorkingDir, "upload")
 	tarFileName, err := b.tar.CreateTarFile(b.config.WorkingDir, uploadDir)

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
@@ -66,7 +67,7 @@ type STI struct {
 // If the layeredBuilder parameter is specified, then the builder provided will
 // be used for the case that the base Docker image does not have 'tar' or 'bash'
 // installed.
-func New(req *api.Config) (*STI, error) {
+func New(req *api.Config, overrides build.Overrides) (*STI, error) {
 	docker, err := dockerpkg.New(req.DockerConfig, req.PullAuthentication)
 	if err != nil {
 		return nil, err
@@ -99,13 +100,18 @@ func New(req *api.Config) (*STI, error) {
 
 	// The sources are downloaded using the GIT downloader.
 	// TODO: Add more SCM in future.
-	b.source, req.Source, err = scm.DownloaderForSource(req.Source)
-	if err != nil {
-		return nil, err
+	b.source = overrides.Downloader
+	if b.source == nil {
+		downloader, sourceURL, err := scm.DownloaderForSource(req.Source)
+		if err != nil {
+			return nil, err
+		}
+		b.source = downloader
+		req.Source = sourceURL
 	}
 
 	b.garbage = &build.DefaultCleaner{b.fs, b.docker}
-	b.layered, err = layered.New(req, b)
+	b.layered, err = layered.New(req, b, overrides)
 
 	// Set interfaces
 	b.preparer = b
@@ -168,8 +174,10 @@ func (b *STI) Build(config *api.Config) (*api.Result, error) {
 // struct Build func leverages the STI struct Prepare func directly below
 func (b *STI) Prepare(config *api.Config) error {
 	var err error
-	if config.WorkingDir, err = b.fs.CreateWorkingDirectory(); err != nil {
-		return err
+	if len(config.WorkingDir) == 0 {
+		if config.WorkingDir, err = b.fs.CreateWorkingDirectory(); err != nil {
+			return err
+		}
 	}
 
 	b.result = &api.Result{
@@ -374,18 +382,6 @@ func (b *STI) Execute(command string, config *api.Config) error {
 
 	buildEnv := append(scripts.ConvertEnvironment(env), b.generateConfigEnv()...)
 
-	uploadDir := filepath.Join(config.WorkingDir, "upload")
-	tarFileName, err := b.tar.CreateTarFile(config.WorkingDir, uploadDir)
-	if err != nil {
-		return err
-	}
-
-	tarFile, err := b.fs.Open(tarFileName)
-	if err != nil {
-		return err
-	}
-	defer tarFile.Close()
-
 	errOutput := ""
 	outReader, outWriter := io.Pipe()
 	errReader, errWriter := io.Pipe()
@@ -410,8 +406,28 @@ func (b *STI) Execute(command string, config *api.Config) error {
 		Env:             buildEnv,
 		PostExec:        b.postExecutor,
 	}
+
 	if !config.LayeredBuild {
-		opts.Stdin = tarFile
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		uploadDir := filepath.Join(config.WorkingDir, "upload")
+
+		// TODO: be able to pass a stream directly to the Docker build to avoid the double temp hit
+		r, w := io.Pipe()
+		go func() {
+			var err error
+			defer func() {
+				w.CloseWithError(err)
+				if r := recover(); r != nil {
+					glog.Errorf("recovered panic: %#v", r)
+				}
+				wg.Done()
+			}()
+			err = b.tar.CreateTarStream(uploadDir, false, w)
+		}()
+
+		opts.Stdin = r
+		defer wg.Wait()
 	}
 
 	go func(reader io.Reader) {

--- a/pkg/build/strategies/sti/usage.go
+++ b/pkg/build/strategies/sti/usage.go
@@ -21,7 +21,7 @@ type Usage struct {
 
 // NewUsage creates a new instance of the default Usage implementation
 func NewUsage(config *api.Config) (*Usage, error) {
-	b, err := New(config)
+	b, err := New(config, build.Overrides{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -13,17 +13,24 @@ import (
 )
 
 // GetStrategy decides what build strategy will be used for the STI build.
+// TODO: deprecated, use Strategy() instead
 func GetStrategy(config *api.Config) (build.Builder, error) {
+	return Strategy(config, build.Overrides{})
+}
+
+// Strategy creates the appropriate build strategy for the provided config, using
+// the overrides provided. Not all strategies support all overrides.
+func Strategy(config *api.Config, overrides build.Overrides) (build.Builder, error) {
 	image, err := GetBuilderImage(config)
 	if err != nil {
 		return nil, err
 	}
 
 	if image.OnBuild {
-		return onbuild.New(config)
+		return onbuild.New(config, overrides)
 	}
 
-	return sti.New(config)
+	return sti.New(config, overrides)
 }
 
 // GetBuilderImage processes the config and performs operations necessary to make

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -36,7 +36,8 @@ type Tar interface {
 	CreateTarFile(base, dir string) (string, error)
 
 	// CreateTarStream creates a tar from the given directory
-	// and streams it to the given writer
+	// and streams it to the given writer.
+	// An error is returned if an error occurs during streaming.
 	CreateTarStream(dir string, includeDirInPath bool, writer io.Writer) error
 
 	// ExtractTarStream extracts files from a given tar stream.
@@ -87,6 +88,7 @@ func (t *stiTar) shouldExclude(path string) bool {
 // CreateTarStream creates a tar stream on the given writer from
 // the given directory while excluding files that match the given
 // exclusion pattern.
+// TODO: this should encapsulate the goroutine that generates the stream.
 func (t *stiTar) CreateTarStream(dir string, includeDirInPath bool, writer io.Writer) error {
 	tarWriter := tar.NewWriter(writer)
 	defer tarWriter.Close()
@@ -148,7 +150,7 @@ func (t *stiTar) writeTarHeader(tarWriter *tar.Writer, dir string, path string, 
 		prefix = filepath.Dir(prefix)
 	}
 	header.Name = filepath.ToSlash(path[1+len(prefix):])
-	glog.V(3).Infof("Adding to tar: %s as %s", path, header.Name)
+	glog.V(5).Infof("Adding to tar: %s as %s", path, header.Name)
 	if err = tarWriter.WriteHeader(header); err != nil {
 		return err
 	}


### PR DESCRIPTION
Origin needs to be able to download and assemble the source
itself and then pass it to s2i. This commit adds changes to
allow an Overrides object to be passed to the s2i initializer
code to provide a custom Downloader.

This also makes changes to allow better reuse of upstream s2i
code and removes a write to disk for the intermediate tar (which
can be streamed instead).

@mfojtik @bparees review, this is part of binary build