### PR TITLE
Revert "Fixing typo"

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
@@ -219,7 +219,7 @@ func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
 				oldStat.Uid() != newStat.Uid() ||
 				oldStat.Gid() != newStat.Gid() ||
 				oldStat.Rdev() != newStat.Rdev() ||
-				// Don't look at size for dirs, it's not a good measure of change
+				// Don't look at size for dirs, its not a good measure of change
 				(oldStat.Mode()&syscall.S_IFDIR != syscall.S_IFDIR &&
 					(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size()))) ||
 				bytes.Compare(oldChild.capability, newChild.capability) != 0 {


### PR DESCRIPTION
This reverts commit edd4961d01fbefca77808e96249cf3cc4900f7d8.