### PR TITLE
Remove glog prefix from build log messages by default

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -120,6 +120,10 @@ type Config struct {
 	// RunImage will trigger a "docker run ..." invocation of the produced image so the user
 	// can see if it operates as he would expect
 	RunImage bool
+
+	// UseLogger will force to use glog instead of printing the output from build
+	// container directly to standard output
+	UseLogger bool
 }
 
 // DockerConfig contains the configuration for a Docker connection

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -2,7 +2,9 @@ package sti
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -445,7 +447,11 @@ func (b *STI) Execute(command string, config *api.Config) error {
 				break
 			}
 			if glog.V(2) || config.Quiet != true || command == api.Usage {
-				glog.Info(text)
+				if (config.UseLogger == true) || glog.V(3) {
+					glog.Info(text)
+					continue
+				}
+				fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(text))
 			}
 		}
 	}(outReader)


### PR DESCRIPTION
This patch will strip the glog prefix from the assemble script that run in container. It should make the logs in OpenShift **much** cleaner.

I also preserved an option to enable the glog programmatically and the glog is on by default for log levels greater than 3.