### PR TITLE
Replace --force-pull with --pull-policy

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -122,7 +122,18 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 				}
 			}
 
-			if len(validation.ValidateConfig(cfg)) != 0 {
+			if cfg.ForcePull {
+				glog.Warning("DEPRECATED: The '--force-pull' option is deprecated. Use '--pull-policy' instead")
+			}
+
+			if len(cfg.BuilderPullPolicy) == 0 {
+				cfg.BuilderPullPolicy = api.DefaultBuilderPullPolicy
+			}
+
+			if errs := validation.ValidateConfig(cfg); len(errs) > 0 {
+				for _, e := range errs {
+					glog.Errorf("%s", e)
+				}
 				cmd.Help()
 				os.Exit(1)
 			}
@@ -160,7 +171,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 			}
 
 			if len(oldScriptsFlag) != 0 {
-				glog.Warning("Flag --scripts is deprecated, use --scripts-url instead")
+				glog.Warning("DEPRECATED: Flag --scripts is deprecated, use --scripts-url instead")
 				cfg.ScriptsURL = oldScriptsFlag
 			}
 			if len(oldDestination) != 0 {
@@ -200,10 +211,11 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.Ref), "ref", "r", "", "Specify a ref to check-out")
 	buildCmd.Flags().StringVar(&(cfg.CallbackURL), "callback-url", "", "Specify a URL to invoke via HTTP POST upon build completion")
 	buildCmd.Flags().StringVarP(&(cfg.ScriptsURL), "scripts-url", "s", "", "Specify a URL for the assemble and run scripts")
-	buildCmd.Flags().StringVar(&(oldScriptsFlag), "scripts", "", "Specify a URL for the assemble and run scripts")
+	buildCmd.Flags().StringVar(&(oldScriptsFlag), "scripts", "", "DEPRECATED: Specify a URL for the assemble and run scripts")
 	buildCmd.Flags().StringVarP(&(oldDestination), "location", "l", "", "Specify a destination location for untar operation")
 	buildCmd.Flags().StringVarP(&(cfg.Destination), "destination", "d", "", "Specify a destination location for untar operation")
-	buildCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", true, "Always pull the builder image even if it is present locally")
+	buildCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", false, "DEPRECATED: Always pull the builder image even if it is present locally")
+	buildCmd.Flags().VarP(&(cfg.BuilderPullPolicy), "pull-policy", "p", "Specify when to pull the builder image (always, never or if-not-present)")
 	buildCmd.Flags().BoolVar(&(cfg.PreserveWorkingDir), "save-temp-dir", false, "Save the temporary directory used by S2I instead of deleting it")
 	buildCmd.Flags().BoolVar(&(useConfig), "use-config", false, "Store command line options to .stifile")
 	buildCmd.Flags().StringVarP(&(cfg.ContextDir), "context-dir", "", "", "Specify the sub-directory inside the repository with the application sources")
@@ -247,6 +259,10 @@ func newCmdRebuild(cfg *api.Config) *cobra.Command {
 				cfg.PullAuthentication = docker.LoadAndGetImageRegistryAuth(r, cfg.BuilderImage)
 			}
 
+			if len(cfg.BuilderPullPolicy) == 0 {
+				cfg.BuilderPullPolicy = api.DefaultBuilderPullPolicy
+			}
+
 			if glog.V(2) {
 				fmt.Printf("\n%s\n", describe.DescribeConfig(cfg))
 			}
@@ -267,7 +283,8 @@ func newCmdRebuild(cfg *api.Config) *cobra.Command {
 	buildCmd.Flags().BoolVar(&(cfg.Incremental), "incremental", false, "Perform an incremental build")
 	buildCmd.Flags().BoolVar(&(cfg.RemovePreviousImage), "rm", false, "Remove the previous image during incremental builds")
 	buildCmd.Flags().StringVar(&(cfg.CallbackURL), "callback-url", "", "Specify a URL to invoke via HTTP POST upon build completion")
-	buildCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", true, "Always pull the builder image even if it is present locally")
+	buildCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", false, "DEPRECATED: Always pull the builder image even if it is present locally")
+	buildCmd.Flags().VarP(&(cfg.BuilderPullPolicy), "pull-policy", "p", "Specify when to pull the builder image (always, never or if-not-present)")
 	buildCmd.Flags().BoolVar(&(cfg.PreserveWorkingDir), "save-temp-dir", false, "Save the temporary directory used by S2I instead of deleting it")
 	buildCmd.Flags().StringVarP(&(cfg.DockerCfgPath), "dockercfg-path", "", filepath.Join(os.Getenv("HOME"), ".docker/config.json"), "Specify the path to the Docker configuration file")
 	return buildCmd
@@ -311,8 +328,12 @@ func newCmdUsage(cfg *api.Config) *cobra.Command {
 			cfg.Environment = envs
 
 			if len(oldScriptsFlag) != 0 {
-				glog.Warning("Flag --scripts is deprecated, use --scripts-url instead")
+				glog.Warning("DEPRECATED: Flag --scripts is deprecated, use --scripts-url instead")
 				cfg.ScriptsURL = oldScriptsFlag
+			}
+
+			if len(cfg.BuilderPullPolicy) == 0 {
+				cfg.BuilderPullPolicy = api.DefaultBuilderPullPolicy
 			}
 
 			uh, err := sti.NewUsage(cfg)
@@ -323,8 +344,9 @@ func newCmdUsage(cfg *api.Config) *cobra.Command {
 	}
 	usageCmd.Flags().StringP("env", "e", "", "Specify an environment var NAME=VALUE,NAME2=VALUE2,...")
 	usageCmd.Flags().StringVarP(&(cfg.ScriptsURL), "scripts-url", "s", "", "Specify a URL for the assemble and run scripts")
-	usageCmd.Flags().StringVar(&(oldScriptsFlag), "scripts", "", "Specify a URL for the assemble and run scripts")
-	usageCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", true, "Always pull the builder image even if it is present locally")
+	usageCmd.Flags().StringVar(&(oldScriptsFlag), "scripts", "", "DEPRECATED: Specify a URL for the assemble and run scripts")
+	usageCmd.Flags().BoolVar(&(cfg.ForcePull), "force-pull", false, "DEPRECATED: Always pull the builder image even if it is present locally")
+	usageCmd.Flags().VarP(&(cfg.BuilderPullPolicy), "pull-policy", "p", "Specify when to pull the builder image (always, never or if-not-present)")
 	usageCmd.Flags().BoolVar(&(cfg.PreserveWorkingDir), "save-temp-dir", false, "Save the temporary directory used by S2I instead of deleting it")
 	usageCmd.Flags().StringVarP(&(oldDestination), "location", "l", "", "Specify a destination location for untar operation")
 	usageCmd.Flags().StringVarP(&(cfg.Destination), "destination", "d", "", "Specify a destination location for untar operation")

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -24,8 +24,13 @@ fi
 
 trap cleanup EXIT SIGINT
 
+export STI_TIMEOUT="-timeout 600s"
+mkdir -p /tmp/sti
+export LOG_FILE="$(mktemp -p /tmp/sti --suffix=integration.log)"
+
 echo
 echo Integration test cases ...
+echo Log file: ${LOG_FILE}
 echo
-export STI_TIMEOUT="-timeout 600s"
-"${STI_ROOT}/hack/test-go.sh" test/integration -tags 'integration' "${@:1}"
+
+"${STI_ROOT}/hack/test-go.sh" test/integration -v -tags 'integration' "${@:1}" 2> ${LOG_FILE}

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 STI_ROOT=$(dirname "${BASH_SOURCE}")/..
+export KILLDONE=""
 
 function time_now()
 {
@@ -17,7 +18,7 @@ function cleanup()
     rm -f  "${STI_ROOT}/hack/sti-run.log"
     # use sigint so that sti post processing will remove docker container
     if [ -z "$KILLDONE" ]; then
-	kill -2 "${STI_PID}"
+	    kill -2 "${STI_PID}"
     fi
     echo
     echo "Complete"
@@ -34,16 +35,13 @@ fi
 
 trap cleanup EXIT SIGINT
 
-echo
-echo 
-echo
-
-sti build git://github.com/bparees/openshift-jee-sample openshift/wildfly-8-centos test-jee-app --run=true &> "${STI_ROOT}/hack/sti-run.log" &
+echo "Running 'sti build --run=true ...'"
+s2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-8-centos test-jee-app --run=true &> "${STI_ROOT}/hack/sti-run.log" &
 export STI_PID=$!
 TIME_SEC=1000
 TIME_MIN=$((60 * $TIME_SEC))
 max_wait=10*TIME_MIN
-echo "waiting up to ${max_wait}"
+echo "Waiting up to ${max_wait} for the build to finish ..."
 expire=$(($(time_now) + $max_wait))
 
 set +e

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -39,7 +39,7 @@ func DescribeConfig(config *api.Config) string {
 			fmt.Fprintf(out, "Incremental Image Pull User:\t%s\n", config.IncrementalAuthentication.Username)
 		}
 		fmt.Fprintf(out, "Remove Old Build:\t%s\n", printBool(config.RemovePreviousImage))
-		fmt.Fprintf(out, "Force Pull:\t%s\n", printBool(config.ForcePull))
+		fmt.Fprintf(out, "Builder Pull Policy:\t%s\n", config.BuilderPullPolicy)
 		fmt.Fprintf(out, "Quiet:\t%s\n", printBool(config.Quiet))
 		fmt.Fprintf(out, "Layered Build:\t%s\n", printBool(config.LayeredBuild))
 		if len(config.Destination) > 0 {
@@ -76,7 +76,7 @@ func describeBuilderImage(config *api.Config, image string, out io.Writer) {
 		DockerConfig:       config.DockerConfig,
 		PullAuthentication: config.PullAuthentication,
 		BuilderImage:       config.BuilderImage,
-		ForcePull:          config.ForcePull,
+		BuilderPullPolicy:  config.BuilderPullPolicy,
 		Tag:                config.Tag,
 		IncrementalAuthentication: config.IncrementalAuthentication,
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	docker "github.com/fsouza/go-dockerclient"
 
 	"github.com/openshift/source-to-image/pkg/util/user"
@@ -10,6 +12,24 @@ import (
 const (
 	DefaultNamespace    = "io.openshift.s2i."
 	KubernetesNamespace = "io.k8s."
+)
+
+const (
+	// PullAlways means that we always attempt to pull the latest image.
+	PullAlways PullPolicy = "always"
+
+	// PullNever means that we never pull an image, but only use a local image.
+	PullNever PullPolicy = "never"
+
+	// PullIfNotPresent means that we pull if the image isn't present on disk.
+	PullIfNotPresent PullPolicy = "if-not-present"
+
+	// DefaultBuilderPullPolicy specifies the default pull policy to use
+	DefaultBuilderPullPolicy = PullIfNotPresent
+
+	// DefaultPreviousImagePullPolicy specifies policy for pulling the previously
+	// build Docker image when doing incremental build
+	DefaultPreviousImagePullPolicy = PullAlways
 )
 
 // Config contains essential fields for performing build.
@@ -65,6 +85,19 @@ type Config struct {
 	// Tag is a result image tag name.
 	Tag string
 
+	// BuilderPullPolicy specifies when to pull the builder image
+	BuilderPullPolicy PullPolicy
+
+	// PreviousImagePullPolicy specifies when to pull the previously build image
+	// when doing incremental build
+	PreviousImagePullPolicy PullPolicy
+
+	// ForcePull defines if the builder image should be always pulled or not.
+	// This is now deprecated by BuilderPullPolicy and will be removed soon.
+	// Setting this to 'true' equals setting BuilderPullPolicy to 'PullAlways'.
+	// Setting this to 'false' equals setting BuilderPullPolicy to 'PullIfNotPresent'
+	ForcePull bool
+
 	// Incremental describes whether to try to perform incremental build.
 	Incremental bool
 
@@ -90,9 +123,6 @@ type Config struct {
 
 	// Destination specifies a location where the untar operation will place its artifacts.
 	Destination string
-
-	// ForcePull describes if the builder should pull the images from registry prior to building.
-	ForcePull bool
 
 	// WorkingDir describes temporary directory used for downloading sources, scripts and tar operations.
 	WorkingDir string
@@ -229,4 +259,39 @@ const (
 // It can be used, for instance, to place the s2i container in the network namespace of the infrastructure container of a k8s pod.
 func NewDockerNetworkModeContainer(id string) DockerNetworkMode {
 	return DockerNetworkMode(DockerNetworkModeContainerPrefix + id)
+}
+
+// PullPolicy specifies a type for the method used to retrieve the Docker image
+type PullPolicy string
+
+// String implements the String() function of pflags.Value so this can be used as
+// command line parameter.
+// This method is really used just to show the default value when printing help.
+// It will not default the configuration.
+func (p *PullPolicy) String() string {
+	if len(string(*p)) == 0 {
+		return string(DefaultBuilderPullPolicy)
+	}
+	return string(*p)
+}
+
+// Type implements the Type() function of pflags.Value interface
+func (p *PullPolicy) Type() string {
+	return "string"
+}
+
+// Set implements the Set() function of pflags.Value interface
+// The valid options are "always", "never" or "if-not-present"
+func (p *PullPolicy) Set(v string) error {
+	switch v {
+	case "always":
+		*p = PullAlways
+	case "never":
+		*p = PullNever
+	case "if-not-present":
+		*p = PullIfNotPresent
+	default:
+		return fmt.Errorf("invalid value %q, valid values are: always, never or if-not-present")
+	}
+	return nil
 }

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -16,6 +16,11 @@ func ValidateConfig(config *api.Config) []ValidationError {
 	if len(config.BuilderImage) == 0 {
 		allErrs = append(allErrs, NewFieldRequired("builderImage"))
 	}
+	switch config.BuilderPullPolicy {
+	case api.PullNever, api.PullAlways, api.PullIfNotPresent:
+	default:
+		allErrs = append(allErrs, NewFieldInvalidValue("builderPullPolicy"))
+	}
 	if config.DockerConfig == nil || len(config.DockerConfig.Endpoint) == 0 {
 		allErrs = append(allErrs, NewFieldRequired("dockerConfig.endpoint"))
 	}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -14,9 +14,10 @@ func TestValidation(t *testing.T) {
 	}{
 		{
 			&api.Config{
-				Source:       "http://github.com/openshift/source",
-				BuilderImage: "openshift/builder",
-				DockerConfig: &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
 			},
 			[]ValidationError{},
 		},
@@ -26,6 +27,7 @@ func TestValidation(t *testing.T) {
 				BuilderImage:      "openshift/builder",
 				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
 				DockerNetworkMode: "foobar",
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
 			},
 			[]ValidationError{{ValidationErrorInvalidValue, "dockerNetworkMode"}},
 		},
@@ -35,6 +37,7 @@ func TestValidation(t *testing.T) {
 				BuilderImage:      "openshift/builder",
 				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
 				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
 			},
 			[]ValidationError{},
 		},

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -3,7 +3,6 @@ package build
 import (
 	"fmt"
 
-	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
 )
@@ -11,21 +10,11 @@ import (
 // GenerateConfigFromLabels generates the S2I Config struct from the Docker
 // image labels.
 func GenerateConfigFromLabels(image string, config *api.Config) error {
-	d, err := docker.New(config.DockerConfig, config.PullAuthentication)
+	result, err := docker.GetBuilderImage(config)
 	if err != nil {
 		return err
 	}
-
-	var source *dockerclient.Image
-	if config.ForcePull {
-		source, err = d.PullImage(image)
-	} else {
-		source, err = d.CheckAndPullImage(image)
-	}
-
-	if err != nil {
-		return err
-	}
+	source := result.Image
 
 	if builderVersion, ok := source.Config.Labels["io.openshift.builder-version"]; ok {
 		config.BuilderImageVersion = builderVersion

--- a/pkg/build/strategies/layered/layered_test.go
+++ b/pkg/build/strategies/layered/layered_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/test"
 )
 
@@ -17,7 +18,7 @@ func (f *FakeExecutor) Execute(string, *api.Config) error {
 
 func newFakeLayered() *Layered {
 	return &Layered{
-		docker:  &test.FakeDocker{},
+		docker:  &docker.FakeDocker{},
 		config:  &api.Config{},
 		fs:      &test.FakeFileSystem{},
 		tar:     &test.FakeTar{},
@@ -75,7 +76,7 @@ func TestBuildErrorOpenTarFile(t *testing.T) {
 
 func TestBuildErrorBuildImage(t *testing.T) {
 	l := newFakeLayered()
-	l.docker.(*test.FakeDocker).BuildImageError = errors.New("BuildImageError")
+	l.docker.(*docker.FakeDocker).BuildImageError = errors.New("BuildImageError")
 	_, err := l.Build(l.config)
 	if err == nil || err.Error() != "BuildImageError" {
 		t.Errorf("An error was expected for BuildImage, but got different: %v", err)

--- a/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/pkg/build/strategies/onbuild/onbuild_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/builder/parser"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/test"
 )
 
@@ -33,7 +34,7 @@ func (*fakeCleaner) Cleanup(*api.Config) {}
 
 func newFakeOnBuild() *OnBuild {
 	return &OnBuild{
-		docker:  &test.FakeDocker{},
+		docker:  &docker.FakeDocker{},
 		git:     &test.FakeGit{},
 		fs:      &test.FakeFileSystem{},
 		tar:     &test.FakeTar{},

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -323,15 +323,18 @@ func (b *STI) Exists(config *api.Config) bool {
 		return false
 	}
 
-	// can only do incremental build if runtime image exists, so always pull image
-	previousImageExists, _ := b.docker.IsImageInLocalRegistry(config.Tag)
-	if !previousImageExists || config.ForcePull {
-		if image, _ := b.incrementalDocker.PullImage(config.Tag); image != nil {
-			previousImageExists = true
-		}
+	policy := config.PreviousImagePullPolicy
+	if len(policy) == 0 {
+		policy = api.DefaultPreviousImagePullPolicy
 	}
 
-	return previousImageExists && b.installedScripts[api.SaveArtifacts]
+	result, err := dockerpkg.PullImage(config.Tag, b.incrementalDocker, policy, false)
+	if err != nil {
+		glog.V(2).Infof("Unable to pull previously build %q image: %v", config.Tag, err)
+		return false
+	}
+
+	return result.Image != nil && b.installedScripts[api.SaveArtifacts]
 }
 
 // Save extracts and restores the build artifacts from the previous build to a
@@ -358,6 +361,7 @@ func (b *STI) Save(config *api.Config) (err error) {
 		ExternalScripts: b.externalScripts[api.SaveArtifacts],
 		ScriptsURL:      config.ScriptsURL,
 		Destination:     config.Destination,
+		PullImage:       false,
 		Command:         api.SaveArtifacts,
 		Stdout:          outWriter,
 		Stderr:          errWriter,
@@ -397,11 +401,14 @@ func (b *STI) Execute(command string, config *api.Config) error {
 	if config.LayeredBuild {
 		externalScripts = false
 	}
+
 	opts := dockerpkg.RunContainerOptions{
-		Image:           config.BuilderImage,
-		Stdout:          outWriter,
-		Stderr:          errWriter,
-		PullImage:       config.ForcePull,
+		Image:  config.BuilderImage,
+		Stdout: outWriter,
+		Stderr: errWriter,
+		// The PullImage is false because the PullImage function should be called
+		// before we run the container
+		PullImage:       false,
 		ExternalScripts: externalScripts,
 		ScriptsURL:      config.ScriptsURL,
 		Destination:     config.Destination,

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -1,15 +1,11 @@
 package strategies
 
 import (
-	dockerclient "github.com/fsouza/go-dockerclient"
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/build/strategies/onbuild"
 	"github.com/openshift/source-to-image/pkg/build/strategies/sti"
 	"github.com/openshift/source-to-image/pkg/docker"
-	"github.com/openshift/source-to-image/pkg/errors"
-	userutil "github.com/openshift/source-to-image/pkg/util/user"
 )
 
 // GetStrategy decides what build strategy will be used for the STI build.
@@ -21,72 +17,12 @@ func GetStrategy(config *api.Config) (build.Builder, error) {
 // Strategy creates the appropriate build strategy for the provided config, using
 // the overrides provided. Not all strategies support all overrides.
 func Strategy(config *api.Config, overrides build.Overrides) (build.Builder, error) {
-	image, err := GetBuilderImage(config)
+	image, err := docker.GetBuilderImage(config)
 	if err != nil {
 		return nil, err
 	}
-
 	if image.OnBuild {
 		return onbuild.New(config, overrides)
 	}
-
 	return sti.New(config, overrides)
-}
-
-// GetBuilderImage processes the config and performs operations necessary to make
-// the Docker image specified as BuilderImage available locally.
-// It returns information about the base image, containing metadata necessary
-// for choosing the right STI build strategy.
-func GetBuilderImage(config *api.Config) (*docker.PullResult, error) {
-	d, err := docker.New(config.DockerConfig, config.PullAuthentication)
-	result := docker.PullResult{}
-	if err != nil {
-		return nil, err
-	}
-
-	var image *dockerclient.Image
-	if config.ForcePull {
-		image, err = d.PullImage(config.BuilderImage)
-		if err != nil {
-			glog.Warningf("An error occurred when pulling %s: %v. Attempting to use local image.", config.BuilderImage, err)
-			image, err = d.CheckImage(config.BuilderImage)
-		}
-	} else {
-		image, err = d.CheckAndPullImage(config.BuilderImage)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	result.Image = image
-	result.OnBuild = d.IsImageOnBuild(config.BuilderImage)
-
-	if err = checkAllowedUser(d, config, result.OnBuild); err != nil {
-		return nil, err
-	}
-
-	return &result, nil
-}
-
-func checkAllowedUser(d docker.Docker, config *api.Config, isOnbuild bool) error {
-	if config.AllowedUIDs == nil || config.AllowedUIDs.Empty() {
-		return nil
-	}
-	user, err := d.GetImageUser(config.BuilderImage)
-	if err != nil {
-		return err
-	}
-	if !userutil.IsUserAllowed(user, &config.AllowedUIDs) {
-		return errors.NewBuilderUserNotAllowedError(config.BuilderImage, false)
-	}
-	if isOnbuild {
-		cmds, err := d.GetOnBuild(config.BuilderImage)
-		if err != nil {
-			return err
-		}
-		if !userutil.IsOnbuildAllowed(cmds, &config.AllowedUIDs) {
-			return errors.NewBuilderUserNotAllowedError(config.BuilderImage, true)
-		}
-	}
-	return nil
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -10,10 +10,11 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 
-	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/errors"
 	"os"
 	"os/signal"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/errors"
 )
 
 const (

--- a/pkg/docker/fake_docker.go
+++ b/pkg/docker/fake_docker.go
@@ -1,11 +1,9 @@
-package test
+package docker
 
 import (
 	"sync"
 
 	dockerclient "github.com/fsouza/go-dockerclient"
-
-	"github.com/openshift/source-to-image/pkg/docker"
 )
 
 // FakeDocker provides a fake docker interface
@@ -18,7 +16,7 @@ type FakeDocker struct {
 	DefaultURLImage              string
 	DefaultURLResult             string
 	DefaultURLError              error
-	RunContainerOpts             docker.RunContainerOptions
+	RunContainerOpts             RunContainerOptions
 	RunContainerError            error
 	RunContainerErrorBeforeStart bool
 	RunContainerContainerID      string
@@ -29,12 +27,12 @@ type FakeDocker struct {
 	GetImageUserImage            string
 	GetImageUserResult           string
 	GetImageUserError            error
-	CommitContainerOpts          docker.CommitContainerOptions
+	CommitContainerOpts          CommitContainerOptions
 	CommitContainerResult        string
 	CommitContainerError         error
 	RemoveImageName              string
 	RemoveImageError             error
-	BuildImageOpts               docker.BuildImageOptions
+	BuildImageOpts               BuildImageOptions
 	BuildImageError              error
 	PullResult                   bool
 	PullError                    error
@@ -80,7 +78,7 @@ func (f *FakeDocker) GetScriptsURL(image string) (string, error) {
 }
 
 // RunContainer runs a fake Docker container
-func (f *FakeDocker) RunContainer(opts docker.RunContainerOptions) error {
+func (f *FakeDocker) RunContainer(opts RunContainerOptions) error {
 	f.RunContainerOpts = opts
 	if f.RunContainerErrorBeforeStart {
 		return f.RunContainerError
@@ -109,7 +107,7 @@ func (f *FakeDocker) GetImageUser(image string) (string, error) {
 }
 
 // CommitContainer commits a fake Docker container
-func (f *FakeDocker) CommitContainer(opts docker.CommitContainerOptions) (string, error) {
+func (f *FakeDocker) CommitContainer(opts CommitContainerOptions) (string, error) {
 	f.CommitContainerOpts = opts
 	return f.CommitContainerResult, f.CommitContainerError
 }
@@ -139,7 +137,7 @@ func (f *FakeDocker) CheckAndPullImage(name string) (*dockerclient.Image, error)
 }
 
 // BuildImage builds image
-func (f *FakeDocker) BuildImage(opts docker.BuildImageOptions) error {
+func (f *FakeDocker) BuildImage(opts BuildImageOptions) error {
 	f.BuildImageOpts = opts
 	return f.BuildImageError
 }

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 
 	"bufio"
+
 	client "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/util/user"
 )
 
 // DockerImageReference points to a Docker image.
@@ -154,4 +158,85 @@ func parseRepositoryTag(repos string) (string, string, string) {
 		return repos[:n], tag, ""
 	}
 	return repos, "", ""
+}
+
+// PullImage pulls the Docker image specifies by name taking the pull policy
+// into the account.
+// TODO: The 'force' option will be removed
+func PullImage(name string, d Docker, policy api.PullPolicy, force bool) (*PullResult, error) {
+	// TODO: Remove this after we deprecate --force-pull
+	if force {
+		policy = api.PullAlways
+	}
+
+	if len(policy) == 0 {
+		return nil, fmt.Errorf("the policy for pull image must be set")
+	}
+
+	var (
+		image *client.Image
+		err   error
+	)
+	switch policy {
+	case api.PullIfNotPresent:
+		image, err = d.CheckAndPullImage(name)
+		return &PullResult{Image: image, OnBuild: d.IsImageOnBuild(name)}, err
+	case api.PullAlways:
+		image, err = d.PullImage(name)
+		if err == nil {
+			return &PullResult{Image: image, OnBuild: d.IsImageOnBuild(name)}, nil
+		}
+		fallthrough
+	case api.PullNever:
+		image, err = d.CheckImage(name)
+	}
+	return &PullResult{Image: image, OnBuild: d.IsImageOnBuild(name)}, err
+}
+
+// CheckAllowedUser checks if the Docker image contains allowed users
+// FIXME: @cswong this need better godoc
+func CheckAllowedUser(d Docker, imageName string, uids user.RangeList, isOnbuild bool) error {
+	if uids == nil || uids.Empty() {
+		return nil
+	}
+	imageUser, err := d.GetImageUser(imageName)
+	if err != nil {
+		return err
+	}
+	if !user.IsUserAllowed(imageUser, &uids) {
+		return errors.NewBuilderUserNotAllowedError(imageName, false)
+	}
+	if isOnbuild {
+		cmds, err := d.GetOnBuild(imageName)
+		if err != nil {
+			return err
+		}
+		if !user.IsOnbuildAllowed(cmds, &uids) {
+			return errors.NewBuilderUserNotAllowedError(imageName, true)
+		}
+	}
+	return nil
+}
+
+// GetBuilderImage processes the config and performs operations necessary to make
+// the Docker image specified as BuilderImage available locally.
+// It returns information about the base image, containing metadata necessary
+// for choosing the right STI build strategy.
+func GetBuilderImage(config *api.Config) (*PullResult, error) {
+	d, err := New(config.DockerConfig, config.PullAuthentication)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := PullImage(config.BuilderImage, d, config.BuilderPullPolicy, config.ForcePull)
+	if err != nil {
+		return nil, err
+	}
+
+	err = CheckAllowedUser(d, config.BuilderImage, config.AllowedUIDs, r.OnBuild)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }

--- a/pkg/docker/util_test.go
+++ b/pkg/docker/util_test.go
@@ -1,10 +1,8 @@
-package strategies
+package docker
 
 import (
 	"testing"
 
-	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/test"
 	"github.com/openshift/source-to-image/pkg/util/user"
 )
 
@@ -83,14 +81,11 @@ func TestCheckAllowedUser(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		cfg := &api.Config{
-			AllowedUIDs: *tc.allowedUIDs,
-		}
-		docker := &test.FakeDocker{
+		docker := &FakeDocker{
 			GetImageUserResult: tc.user,
 			OnBuildResult:      tc.onbuild,
 		}
-		err := checkAllowedUser(docker, cfg, len(tc.onbuild) > 0)
+		err := CheckAllowedUser(docker, "", *tc.allowedUIDs, len(tc.onbuild) > 0)
 		if err != nil && !tc.expectErr {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		}

--- a/pkg/scripts/install_test.go
+++ b/pkg/scripts/install_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/test"
 )
@@ -14,7 +15,7 @@ func getFakeInstaller() *installer {
 	return &installer{
 		image:      "test-image",
 		scriptsURL: "http://the.scripts.url/scripts",
-		docker:     &test.FakeDocker{},
+		docker:     &docker.FakeDocker{},
 		downloader: &test.FakeDownloader{},
 		fs:         &test.FakeFileSystem{},
 	}
@@ -35,7 +36,7 @@ func TestInstallRequiredError(t *testing.T) {
 func TestRun(t *testing.T) {
 	inst := getFakeInstaller()
 	defaultURL := "http://the.default.url"
-	inst.docker.(*test.FakeDocker).DefaultURLResult = defaultURL
+	inst.docker.(*docker.FakeDocker).DefaultURLResult = defaultURL
 	scriptsURL := "http://the.scripts.url"
 	inst.scriptsURL = scriptsURL
 	workingDir := "/working-dir/"


### PR DESCRIPTION
This will replace the --force-pull with --pull-policy option. This option default to "if-not-present" which means that the Docker image will be pull only if it does not exists locally.

Valid options are "always", "never" or "if-not-present".

* `always` will always try to pull the Docker image first and then check if the local image exists
* `if-not-present` will honor the local image and only in case the local image does not exists, it will attempt to pull it
* `never` will never perform pull and always use the local image

Fixes: https://github.com/openshift/source-to-image/issues/273