### PR TITLE
WIP: Stop using filepath.Join on windows

### DIFF
--- a/pkg/build/strategies/layered/layered.go
+++ b/pkg/build/strategies/layered/layered.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -141,7 +142,7 @@ func (b *Layered) Build(config *api.Config) (*api.Result, error) {
 	// new image name
 	b.config.BuilderImage = newBuilderImage
 	// the scripts are inside the image
-	b.config.ScriptsURL = "image://" + filepath.Join(getDestination(config), "scripts")
+	b.config.ScriptsURL = "image://" + path.Join(getDestination(config), "scripts")
 
 	glog.V(2).Infof("Building %s using sti-enabled image", b.config.Tag)
 	if err := b.scripts.Execute(api.Assemble, b.config); err != nil {

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -267,11 +268,13 @@ func (b *STI) PostExecute(containerID, location string) error {
 	runCmd := b.scriptsURL[api.Run]
 	if strings.HasPrefix(runCmd, "image://") {
 		// scripts from inside of the image, we need to strip the image part
-		runCmd = filepath.Join(strings.TrimPrefix(runCmd, "image://"), api.Run)
+		// NOTE: We use path.Join instead of filepath.Join to avoid converting the
+		// path to UNC (Windows) format as we always run this inside container.
+		runCmd = path.Join(strings.TrimPrefix(runCmd, "image://"), api.Run)
 	} else {
 		// external scripts, in which case we're taking the directory to which they
 		// were extracted and append scripts dir and name
-		runCmd = filepath.Join(location, "scripts", api.Run)
+		runCmd = path.Join(location, "scripts", api.Run)
 	}
 	existingLabels, err := b.docker.GetLabels(b.config.BuilderImage)
 	if err != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -371,7 +371,9 @@ func runContainerTar(opts RunContainerOptions, config docker.Config, imageMetada
 	if opts.ExternalScripts {
 		// for external scripts we must always append 'scripts' because this is
 		// the default subdirectory inside tar for them
-		commandBaseDir = filepath.Join(tarDestination, "scripts")
+		// NOTE: We use path.Join instead of filepath.Join to avoid converting the
+		// path to UNC (Windows) format as we always run this inside container.
+		commandBaseDir = path.Join(tarDestination, "scripts")
 		glog.V(2).Infof("Both scripts and untarred source will be placed in '%s'", tarDestination)
 	} else {
 		// for internal scripts we can have separate path for scripts and untar operation destination
@@ -384,12 +386,14 @@ func runContainerTar(opts RunContainerOptions, config docker.Config, imageMetada
 			commandBaseDir, tarDestination)
 	}
 
-	cmd := []string{filepath.Join(commandBaseDir, string(opts.Command))}
+	// NOTE: We use path.Join instead of filepath.Join to avoid converting the
+	// path to UNC (Windows) format as we always run this inside container.
+	cmd := []string{path.Join(commandBaseDir, string(opts.Command))}
 	// when calling assemble script with Stdin parameter set (the tar file)
 	// we need to first untar the whole archive and only then call the assemble script
 	if opts.Stdin != nil && (opts.Command == api.Assemble || opts.Command == api.Usage) {
 		cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar -C %s -xf - && %s",
-			tarDestination, filepath.Join(commandBaseDir, string(opts.Command)))}
+			tarDestination, path.Join(commandBaseDir, string(opts.Command)))}
 	}
 	config.Cmd = cmd
 	return config, tarDestination


### PR DESCRIPTION
The problem is that we should never using `filepath.Join` when constructing the path we later use in container (like assemble path). If this code is called on Windows, the final path will not be UNIX but Windows path, which will lead to stripping all path separators.

Fixes: https://github.com/openshift/source-to-image/issues/314