### PR TITLE
Fix copying of local file directory

### DIFF
--- a/pkg/scm/file/download.go
+++ b/pkg/scm/file/download.go
@@ -25,7 +25,7 @@ func (f *File) Download(config *api.Config) (*api.SourceInfo, error) {
 	}
 
 	glog.V(1).Infof("Copying sources from %q to %q", sourceDir, targetSourceDir)
-	err := f.Copy(sourceDir, targetSourceDir)
+	err := f.CopyContents(sourceDir, targetSourceDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/fs.go
+++ b/pkg/test/fs.go
@@ -139,6 +139,13 @@ func (f *FakeFileSystem) Copy(sourcePath, targetPath string) error {
 	return f.CopyError
 }
 
+// CopyContents copies directory contents on the fake filesystem
+func (f *FakeFileSystem) CopyContents(sourcePath, targetPath string) error {
+	f.CopySource = sourcePath
+	f.CopyDest = targetPath
+	return f.CopyError
+}
+
 // RemoveDirectory removes a directory in the fake filesystem
 func (f *FakeFileSystem) RemoveDirectory(dir string) error {
 	f.RemoveDirName = dir


### PR DESCRIPTION
When specifying a local directory (that is not a git repo), we copy the files from it to a temporary upload/src directory using ```cp -a``` For the contents of the directory to be copied and not the directory itself to be copied, the directory spec must end in "/".  