### PR TITLE
Add additional fields for author and committer to git.SourceInfo

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -220,9 +220,19 @@ type SourceInfo struct {
 	// The output image will contain this information as 'io.openshift.build.commit.date' label.
 	Date string
 
-	// Author contains information about the committer name and email address.
-	// The output image will contain this information as 'io.openshift.build.commit.author' label.
-	Author string
+	// AuthorName contains the name of the author
+	// The output image will contain this information (along with AuthorEmail) as 'io.openshift.build.commit.author' label.
+	AuthorName string
+
+	// AuthorEmail contains the e-mail of the author
+	// The output image will contain this information (along with AuthorName) as 'io.openshift.build.commit.author' lablel.
+	AuthorEmail string
+
+	// CommitterName contains the name of the committer
+	CommitterName string
+
+	// CommitterEmail contains the e-mail of the committer
+	CommitterEmail string
 
 	// Message represents the first 80 characters from the commit message.
 	// The output image will contain this information as 'io.openshift.build.commit.message' label.

--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -436,12 +436,15 @@ func (h *stiGit) GetInfo(repo string) *api.SourceInfo {
 		return strings.TrimSpace(string(out))
 	}
 	return &api.SourceInfo{
-		Location: git("config", "--get", "remote.origin.url"),
-		Ref:      git("rev-parse", "--abbrev-ref", "HEAD"),
-		CommitID: git("rev-parse", "--verify", "HEAD"),
-		Author:   git("--no-pager", "show", "-s", "--format=%an <%ae>", "HEAD"),
-		Date:     git("--no-pager", "show", "-s", "--format=%ad", "HEAD"),
-		Message:  git("--no-pager", "show", "-s", "--format=%<(80,trunc)%s", "HEAD"),
+		Location:       git("config", "--get", "remote.origin.url"),
+		Ref:            git("rev-parse", "--abbrev-ref", "HEAD"),
+		CommitID:       git("rev-parse", "--verify", "HEAD"),
+		AuthorName:     git("--no-pager", "show", "-s", "--format=%an", "HEAD"),
+		AuthorEmail:    git("--no-pager", "show", "-s", "--format=%ae", "HEAD"),
+		CommitterName:  git("--no-pager", "show", "-s", "--format=%cn", "HEAD"),
+		CommitterEmail: git("--no-pager", "show", "-s", "--format=%ce", "HEAD"),
+		Date:           git("--no-pager", "show", "-s", "--format=%ad", "HEAD"),
+		Message:        git("--no-pager", "show", "-s", "--format=%<(80,trunc)%s", "HEAD"),
 	}
 }
 

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 )
@@ -43,7 +45,9 @@ func GenerateLabelsFromSourceInfo(labels map[string]string, info *api.SourceInfo
 		return labels
 	}
 
-	addBuildLabel(labels, "commit.author", info.Author, namespace)
+	author := fmt.Sprintf("%s <%s>", info.AuthorName, info.AuthorEmail)
+
+	addBuildLabel(labels, "commit.author", author, namespace)
 	addBuildLabel(labels, "commit.date", info.Date, namespace)
 	addBuildLabel(labels, "commit.id", info.CommitID, namespace)
 	addBuildLabel(labels, "commit.ref", info.Ref, namespace)


### PR DESCRIPTION
Separates the author info and adds committer info so it can be used by Origin code.