### PR TITLE
don't prepend file:// to url path with MungeNoProto

### DIFF
--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -236,7 +236,7 @@ func ParseFile(source string) (details *FileProtoDetails, mods *URLMods) {
 		}
 		mods = &URLMods{
 			Scheme: "file",
-			Path:   "file://" + makePathAbsolute(strings.TrimPrefix(source, "file://")),
+			Path:   makePathAbsolute(strings.TrimPrefix(source, "file://")),
 		}
 		return
 	}
@@ -279,7 +279,7 @@ func ParseFile(source string) (details *FileProtoDetails, mods *URLMods) {
 		}
 		mods = &URLMods{
 			Scheme: "file",
-			Path:   "file://" + makePathAbsolute(strings.TrimPrefix(source, "file://")),
+			Path:   makePathAbsolute(strings.TrimPrefix(source, "file://")),
 			Ref:    ref,
 		}
 		return

--- a/pkg/scm/git/git_test.go
+++ b/pkg/scm/git/git_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -111,6 +112,127 @@ func TestValidCloneSpecRemoteOnly(t *testing.T) {
 		result := gh.ValidCloneSpecRemoteOnly(scenario)
 		if result {
 			t.Error(scenario)
+		}
+	}
+}
+
+func TestMungeNoProtocolURL(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+
+	gh := New()
+
+	tests := map[string]url.URL{
+		"git@github.com:user/repo.git": {
+			Scheme: "ssh",
+			Host:   "github.com",
+			User:   url.User("git"),
+			Path:   "user/repo.git",
+		},
+		"git://github.com/user/repo.git": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"git://github.com/user/repo": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"http://github.com/user/repo.git": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"http://github.com/user/repo": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"https://github.com/user/repo.git": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"https://github.com/user/repo": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"file://" + gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		"git@192.168.122.1:repositories/authooks": {
+			Scheme: "ssh",
+			Host:   "192.168.122.1",
+			User:   url.User("git"),
+			Path:   "repositories/authooks",
+		},
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git": {
+			Scheme: "ssh",
+			Host:   "build.ulx.hu",
+			User:   url.User("mbalazs"),
+			Path:   "/var/git/eap-ulx.git",
+		},
+		"ssh://git@[2001:db8::1]/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+		"ssh://git@mydomain.com:8080/foo/bar": {
+			Scheme: "ssh",
+			Host:   "mydomain.com:8080",
+			User:   url.User("git"),
+			Path:   "/foo/bar",
+		},
+		"git@[2001:db8::1]:repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "repository.git",
+		},
+		"git@[2001:db8::1]:/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+	}
+
+	for scenario, test := range tests {
+		uri, err := url.Parse(scenario)
+		if err != nil {
+			t.Errorf("Could not parse url %s", scenario)
+		}
+
+		err = gh.MungeNoProtocolURL(scenario, uri)
+		if err != nil {
+			t.Errorf("MungeNoProtocolURL returned err: %v", err)
+		}
+
+		// reflect.DeepEqual was not dealing with url.URL correctly, have to check each field individually
+		// First, the easy string compares
+		equal := uri.Scheme == test.Scheme && uri.Opaque == test.Opaque && uri.Host == test.Host && uri.Path == test.Path && uri.RawQuery == test.RawQuery && uri.Fragment == test.Fragment
+		if equal {
+			// now deal with User, a Userinfo struct ptr
+			if uri.User == nil && test.User != nil {
+				equal = false
+			} else if uri.User != nil && test.User == nil {
+				equal = false
+			} else if uri.User != nil && test.User != nil {
+				equal = uri.User.String() == test.User.String()
+			}
+		}
+		if !equal {
+			t.Errorf("For URL string %s, field by field check for scheme %v opaque %v host %v path %v rawq %v frag %v out user nil %v test user nil %v out scheme  %s out opaque %s out host %s out path %s  out raw query %s out frag %s", scenario,
+				uri.Scheme == test.Scheme, uri.Opaque == test.Opaque, uri.Host == test.Host, uri.Path == test.Path, uri.RawQuery == test.RawQuery,
+				uri.Fragment == test.Fragment, uri.User == nil, test.User == nil, uri.Scheme, uri.Opaque, uri.Host, uri.Path, uri.RawQuery, uri.Fragment)
 		}
 	}
 }

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -24,8 +24,15 @@ func DownloaderForSource(s string) (build.Downloader, string, error) {
 	}
 
 	if details.FileExists && mods != nil {
-		glog.V(4).Infof("new path from parse file %s", mods.Path)
-		s = mods.Path
+		glog.V(4).Infof("new source from parse file %s", mods.Path)
+		if details.ProtoSpecified {
+			s = mods.Path
+		} else {
+			// prepending with file:// is a precautionary step which previous incarnations of this code did; we
+			// preserve that behavior (it is more explicit, if not absolutely necessary; but we do it here as was done before
+			// vs. down in our generic git layer (which is leveraged separately in origin)
+			s = "file://" + mods.Path
+		}
 	}
 
 	if details.FileExists && details.UseCopy {

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -44,12 +44,18 @@ func TestDownloaderForSource(t *testing.T) {
 	}
 
 	for s, expected := range tc {
-		r, _, err := DownloaderForSource(s)
+		r, filePathUpdate, err := DownloaderForSource(s)
 		if err != nil {
 			if expected != "error" {
 				t.Errorf("Unexpected error %q for %q, expected %q", err, s, expected)
 			}
 			continue
+		}
+
+		if s == gitLocalDir || s == localDir {
+			if !strings.HasPrefix(filePathUpdate, "file://") {
+				t.Errorf("input %s should have produced a file path update starting with file:// but produced:  %s", s, filePathUpdate)
+			}
 		}
 
 		expected = "*" + expected


### PR DESCRIPTION
@bparees the one small piece of clean up from the origin testing of the clone spec / url validation pull ; there is a short term work around to the caller of MungeNoProtocolURL on the origin side (pkg/generate/git/git.go) (no callers on the source-to-image side).  The origin side change can tolerate MungeNoProtocolURL either prefixing or not prefixing the path with "file://".

We can godeps merge this change and remove the workaround in origin at our convenience.

PTAL when you get the chance - thx