### PR TITLE
changed /usr/local to /usr/libexec/

### DIFF
--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -332,7 +332,7 @@ func TestPostExecute(t *testing.T) {
 		}
 		ci := bh.callbackInvoker.(*test.FakeCallbackInvoker)
 		if tc.scriptsFromImage {
-			bh.scriptsURL = map[string]string{api.Run: "image:///usr/local/sti"}
+			bh.scriptsURL = map[string]string{api.Run: "image:///usr/libexec/s2i"}
 		}
 		err := bh.PostExecute(containerID, "cmd1")
 		if err != nil {
@@ -341,7 +341,7 @@ func TestPostExecute(t *testing.T) {
 		// Ensure CommitContainer was called with the right parameters
 		expectedCmd := []string{"cmd1/scripts/" + api.Run}
 		if tc.scriptsFromImage {
-			expectedCmd = []string{"/usr/local/sti/" + api.Run}
+			expectedCmd = []string{"/usr/libexec/s2i/" + api.Run}
 		}
 		if !reflect.DeepEqual(dh.CommitContainerOpts.Command, expectedCmd) {
 			t.Errorf("(%d) Unexpected commit container command: %#v", i, dh.CommitContainerOpts.Command)

--- a/pkg/create/templates/docker.go
+++ b/pkg/create/templates/docker.go
@@ -22,8 +22,8 @@ FROM openshift/base-centos7
 # TODO (optional): Copy the builder files into /opt/app-root
 # COPY ./<builder_folder>/ /opt/app-root/
 
-# TODO: Copy the S2I scripts to /usr/local/s2i, since openshift/base-centos7 image sets io.openshift.s2i.scripts-url label that way, or update that label
-# COPY ./.s2i/bin/ /usr/local/s2i
+# TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image sets io.openshift.s2i.scripts-url label that way, or update that label
+# COPY ./.s2i/bin/ /usr/libexec/s2i
 
 # TODO: Drop the root user and make the content of /opt/app-root owned by user 1001
 # RUN chown -R 1001:1001 /opt/app-root

--- a/pkg/create/templates/scripts.go
+++ b/pkg/create/templates/scripts.go
@@ -12,7 +12,7 @@ const AssembleScript = `#!/bin/bash -e
 if [ "$1" = "-h" ]; then
 	# If the '{{.ImageName}}' assemble script is executed with '-h' flag,
 	# print the usage.
-	exec /usr/local/s2i/usage
+	exec /usr/libexec/s2i/usage
 fi
 
 # Restore artifacts from the previous build (if they exist).


### PR DESCRIPTION
i noticed that the generator scripts still use the old /usr/local for assemble, run, etc. so i've changed it to the new localtion /usr/libexec/s2i as mentioned in this [sti-base image PR](https://github.com/openshift/sti-base/pull/60) also modified it in the tests.

my question is, should it be done this way, hard coded or should we set it according to the env variable $STI_SCRIPTS_PATH set in sti-base in case this path changes again?

Later Edit: nvm, found my answer to the question: https://github.com/openshift/source-to-image/pull/302/files#r41652962