### PR TITLE
Support injecting files into a container that runs assemble script

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -175,6 +175,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
 	buildCmd.Flags().VarP(&(cfg.AllowedUIDs), "allowed-uids", "u", "Specify a range of allowed user ids for the builder image")
+	buildCmd.Flags().VarP(&(cfg.Injections), "inject", "i", "Specify a list of directories to inject into the assemble container")
 	buildCmd.Flags().StringVarP(&(oldDestination), "location", "l", "",
 		"DEPRECATED: Specify a destination location for untar operation")
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,12 +86,36 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 | `-s (--scripts-url)`       | URL of S2I scripts (see [S2I Scripts](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts)) |
 | `--recursive`              | Perform recursive git clone when getting sources using git|
 | `-q (--quiet)`             | Operate quietly, suppressing all non-error output |
+| `--inject`                 | Inject the content of the specified directory into the path in the container that runs the assemble script |
 
 #### Context directory
 
 In the case where your application resides in a directory other than your repository root
 folder, you can specify that directory using the `--context-dir` parameter. The
 specified directory will be used as your application root folder.
+
+#### Injecting directories to build
+
+If you want to inject files that should only be available during the build (ie
+when the assemble script is invoked), you can specify the directories from which
+the files will be copied into the container that runs the assemble script. To do
+so you can invoke S2I as follows:
+
+```console
+$ s2i build --inject /mydir:/container/dir file://source builder-image output-image
+```
+
+In this case the content of the `/mydir` directory will get copied into
+`/container/dir` inside the container which runs the assemble script.
+After the `assemble` script finishes, all files copied will be truncated and thus
+not available in the output image. The files are truncated instead of deleted
+because the user under which we run the container with the assemble script might not
+have permissions to delete files in the destination directory (eg. `/etc/ssl`).
+
+You can also specify multiple directories, for example: `--inject /dir1:/container/dir1 --inject /dir2:container/dir2`.
+
+You can use this feature to provide SSL certificates, private configuration
+files which contains credentials, etc. 
 
 #### Callback URL
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,0 +1,45 @@
+package api
+
+import "testing"
+
+func TestInjectionListSet(t *testing.T) {
+	table := map[string][]InjectPath{
+		"/test:":             {{SourcePath: "/test", DestinationDir: "."}},
+		"/test:/test":        {{SourcePath: "/test", DestinationDir: "/test"}},
+		"/test/foo:/etc/ssl": {{SourcePath: "/test/foo", DestinationDir: "/etc/ssl"}},
+		":/foo":              {{SourcePath: ".", DestinationDir: "/foo"}},
+		"/foo":               {{SourcePath: "/foo", DestinationDir: "."}},
+		":":                  {{SourcePath: ".", DestinationDir: "."}},
+		"/t est/foo:":        {{SourcePath: "/t est/foo", DestinationDir: "."}},
+		`"/test":"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
+		`'/test':"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
+		`"/te"st":"/foo"`:    {},
+		"/test/foo:/ss;ss":   {},
+		"/test;foo:/ssss":    {},
+	}
+	for v, expected := range table {
+		got := InjectionList{}
+		err := got.Set(v)
+		if len(expected) == 0 {
+			if err == nil {
+				t.Errorf("Expected error for %q, got %#v", v, got)
+			} else {
+				continue
+			}
+		}
+		if len(got) != len(expected) {
+			t.Errorf("Expected %d injection in the list for %q, got %d", len(expected), v, len(got))
+		}
+		for _, exp := range expected {
+			found := false
+			for _, g := range got {
+				if g.SourcePath == exp.SourcePath && g.DestinationDir == exp.DestinationDir {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Expected %+v injection found in %#v list", exp, got)
+			}
+		}
+	}
+}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -368,7 +368,7 @@ func (b *STI) Save(config *api.Config) (err error) {
 	defer errReader.Close()
 	defer errWriter.Close()
 	glog.V(1).Infof("Saving build artifacts from image %s to path %s", image, artifactTmpDir)
-	extractFunc := func() error {
+	extractFunc := func(string) error {
 		defer outReader.Close()
 		return b.tar.ExtractTarStream(artifactTmpDir, outReader)
 	}
@@ -446,6 +446,44 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 		User:            user,
 		PostExec:        b.postExecutor,
 		NetworkMode:     string(config.DockerNetworkMode),
+	}
+
+	// If there are injections specified, override the original assemble script
+	// and wait till all injections are uploaded into the container that runs the
+	// assemble script.
+	if len(config.Injections) > 0 && command == api.Assemble {
+		injectedFiles, err := util.ExpandInjectedFiles(config.Injections)
+		if err != nil {
+			return err
+		}
+		rmScript, err := util.CreateInjectedFilesRemovalScript(injectedFiles)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(rmScript)
+		glog.V(5).Infof("Waiting for injected files to be copied into assemble container...")
+		opts.CommandOverrides = func(cmd string) string {
+			return fmt.Sprintf("while [ ! -f %q ]; do sleep 0.5; done; %s; result=$?; source %[1]s; exit $result",
+				"/tmp/rm-injections", cmd)
+		}
+		originalOnStart := opts.OnStart
+		opts.OnStart = func(containerID string) error {
+			if err != nil {
+				return err
+			}
+			for _, s := range config.Injections {
+				if err := b.docker.UploadToContainer(s.SourcePath, s.DestinationDir, containerID); err != nil {
+					return err
+				}
+			}
+			if err := b.docker.UploadToContainer(rmScript, "/tmp/rm-injections", containerID); err != nil {
+				return err
+			}
+			if originalOnStart != nil {
+				return originalOnStart(containerID)
+			}
+			return nil
+		}
 	}
 
 	if !config.LayeredBuild {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/tar"
 )
 
 const (
@@ -63,6 +65,7 @@ type Docker interface {
 	BuildImage(opts BuildImageOptions) error
 	GetImageUser(name string) (string, error)
 	GetLabels(name string) (map[string]string, error)
+	UploadToContainer(srcPath, destPath, name string) error
 	Ping() error
 }
 
@@ -76,6 +79,7 @@ type Client interface {
 	AttachToContainer(opts docker.AttachToContainerOptions) error
 	StartContainer(id string, hostConfig *docker.HostConfig) error
 	WaitContainer(id string) (int, error)
+	UploadToContainer(id string, opts docker.UploadToContainerOptions) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error
 	CommitContainer(opts docker.CommitContainerOptions) (*docker.Image, error)
 	CopyFromContainer(opts docker.CopyFromContainerOptions) error
@@ -100,22 +104,23 @@ type PullResult struct {
 
 // RunContainerOptions are options passed in to the RunContainer method
 type RunContainerOptions struct {
-	Image           string
-	PullImage       bool
-	PullAuth        docker.AuthConfiguration
-	ExternalScripts bool
-	ScriptsURL      string
-	Destination     string
-	Command         string
-	Env             []string
-	Stdin           io.Reader
-	Stdout          io.Writer
-	Stderr          io.Writer
-	OnStart         func() error
-	PostExec        PostExecutor
-	TargetImage     bool
-	NetworkMode     string
-	User            string
+	Image            string
+	PullImage        bool
+	PullAuth         docker.AuthConfiguration
+	ExternalScripts  bool
+	ScriptsURL       string
+	Destination      string
+	Command          string
+	CommandOverrides func(originalCmd string) string
+	Env              []string
+	Stdin            io.Reader
+	Stdout           io.Writer
+	Stderr           io.Writer
+	OnStart          func(containerID string) error
+	PostExec         PostExecutor
+	TargetImage      bool
+	NetworkMode      string
+	User             string
 }
 
 // CommitContainerOptions are options passed in to the CommitContainer method
@@ -155,6 +160,42 @@ func New(config *api.DockerConfig, auth docker.AuthConfiguration) (Docker, error
 		client:   client,
 		pullAuth: auth,
 	}, nil
+}
+
+// UploadToContainer uploads artifacts to the container.
+// If the source is a directory, then all files and sub-folders are copied into
+// the destination (which has to be directory as well).
+// If the source is a single file, then the file copied into destination (which
+// has to be full path to a file inside the container).
+func (d *stiDocker) UploadToContainer(src, dest, name string) error {
+	path := filepath.Dir(dest)
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	info, _ := f.Stat()
+	defer f.Close()
+	t := tar.New()
+	r, w := io.Pipe()
+	if info.IsDir() {
+		path = dest
+		go func() {
+			defer w.Close()
+			if err := t.StreamDirAsTar(src, dest, w); err != nil {
+				glog.Errorf("Uploading directory to container failed: %v", err)
+			}
+		}()
+	} else {
+		go func() {
+			defer w.Close()
+			if err := t.StreamFileAsTar(src, filepath.Base(dest), w); err != nil {
+				glog.Errorf("Uploading files to container failed: %v", err)
+			}
+		}()
+	}
+	glog.V(3).Infof("Uploading %q to %q ...", src, path)
+	opts := docker.UploadToContainerOptions{Path: path, InputStream: r}
+	return d.client.UploadToContainer(name, opts)
 }
 
 // IsImageInLocalRegistry determines whether the supplied image is in the local registry.
@@ -405,9 +446,12 @@ func runContainerTar(opts RunContainerOptions, config docker.Config, imageMetada
 	// when calling assemble script with Stdin parameter set (the tar file)
 	// we need to first untar the whole archive and only then call the assemble script
 	if opts.Stdin != nil && (opts.Command == api.Assemble || opts.Command == api.Usage) {
-		cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar -C %s -xf - && %s",
-			tarDestination, path.Join(commandBaseDir, string(opts.Command)))}
+		cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar -C %s -xf - && %s", tarDestination, cmd[0])}
+		if opts.CommandOverrides != nil {
+			cmd = []string{"/bin/sh", "-c", opts.CommandOverrides(strings.Join(cmd[2:], " "))}
+		}
 	}
+	glog.V(5).Infof("Running %q command in container ...", strings.Join(cmd, " "))
 	config.Cmd = cmd
 	return config, tarDestination
 }
@@ -551,7 +595,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) (err error) {
 		return err
 	}
 	if opts.OnStart != nil {
-		if err = opts.OnStart(); err != nil {
+		if err = opts.OnStart(container.ID); err != nil {
 			return err
 		}
 	}

--- a/pkg/docker/fake_docker.go
+++ b/pkg/docker/fake_docker.go
@@ -89,7 +89,7 @@ func (f *FakeDocker) RunContainer(opts RunContainerOptions) error {
 		return f.RunContainerError
 	}
 	if opts.OnStart != nil {
-		if err := opts.OnStart(); err != nil {
+		if err := opts.OnStart(""); err != nil {
 			return err
 		}
 	}
@@ -97,6 +97,10 @@ func (f *FakeDocker) RunContainer(opts RunContainerOptions) error {
 		opts.PostExec.PostExecute(f.RunContainerContainerID, string(opts.Command))
 	}
 	return f.RunContainerError
+}
+
+func (f *FakeDocker) UploadToContainer(srcPath, destPath, name string) error {
+	return nil
 }
 
 // GetImageID returns a fake Docker image ID

--- a/pkg/docker/test/client.go
+++ b/pkg/docker/test/client.go
@@ -107,6 +107,10 @@ func (d *FakeDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 	return d.StartContainerErr
 }
 
+func (d *FakeDockerClient) UploadToContainer(id string, opts docker.UploadToContainerOptions) error {
+	return nil
+}
+
 // WaitContainer waits for a fake container to finish
 func (d *FakeDockerClient) WaitContainer(id string) (int, error) {
 	d.WaitContainerID = id

--- a/pkg/test/tar.go
+++ b/pkg/test/tar.go
@@ -52,6 +52,14 @@ func (f *FakeTar) ExtractTarStream(dir string, reader io.Reader) error {
 func (f *FakeTar) SetExclusionPattern(*regexp.Regexp) {
 }
 
+func (f *FakeTar) StreamFileAsTar(string, string, io.Writer) error {
+	return nil
+}
+
+func (f *FakeTar) StreamDirAsTar(string, string, io.Writer) error {
+	return nil
+}
+
 func (f *FakeTar) CreateTarStreamWithLogging(dir string, includeDirInPath bool, writer io.Writer, logger io.Writer) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+// ExpandInjectedFiles returns a flat list of all files that are injected into a
+// container. All files from nested directories are returned in the list.
+func ExpandInjectedFiles(injections api.InjectionList) ([]string, error) {
+	result := []string{}
+	for _, s := range injections {
+		info, err := os.Stat(s.SourcePath)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("the %q must be a valid directory", s.SourcePath)
+		}
+		err = filepath.Walk(s.SourcePath, func(path string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if f.IsDir() {
+				return nil
+			}
+			newPath := filepath.Join(s.DestinationDir, strings.TrimPrefix(path, s.SourcePath))
+			result = append(result, newPath)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// CreateInjectedFilesRemovalScript creates a shell script that contains truncation
+// of all files we injected into the container. The path to the script is returned.
+func CreateInjectedFilesRemovalScript(files []string) (string, error) {
+	rmScript := "set -e\n"
+	for _, s := range files {
+		rmScript += fmt.Sprintf("truncate -s0 %q\n", s)
+	}
+
+	f, err := ioutil.TempFile("", "s2i-injection-remove")
+	if err != nil {
+		return "", err
+	}
+	rmScript += "set +e\n"
+	err = ioutil.WriteFile(f.Name(), []byte(rmScript), 0700)
+	return f.Name(), err
+}

--- a/pkg/util/injection_test.go
+++ b/pkg/util/injection_test.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestCreateInjectedFilesRemovalScript(t *testing.T) {
+	files := []string{
+		"/foo",
+		"/bar/bar",
+	}
+	name, err := CreateInjectedFilesRemovalScript(files)
+	defer os.Remove(name)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", name)
+	}
+	_, err = os.Stat(name)
+	if err != nil {
+		t.Errorf("Expected file %q to exists, got: %v", name, err)
+	}
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		t.Errorf("Unable to read %q: %v", name, err)
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("truncate -s0 %q", "/foo")) {
+		t.Errorf("Expected script to contain truncate -s0 \"/foo\", got: %q", string(data))
+	}
+}
+
+func TestExpandInjectedFiles(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "s2i-test-")
+	tmpNested, err := ioutil.TempDir(tmp, "nested")
+	if err != nil {
+		t.Errorf("Unable to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	list := api.InjectionList{{SourcePath: tmp, DestinationDir: "/foo"}}
+	f1, _ := ioutil.TempFile(tmp, "foo")
+	f2, _ := ioutil.TempFile(tmpNested, "bar")
+	files, err := ExpandInjectedFiles(list)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := []string{"/foo/" + filepath.Base(f1.Name()), filepath.Join("/foo", filepath.Base(tmpNested), filepath.Base(f2.Name()))}
+	for _, exp := range expected {
+		found := false
+		for _, f := range files {
+			if f == exp {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected %q in resulting file list, got %+v", exp, files)
+		}
+	}
+}

--- a/test/integration/scripts/.sti/bin/assemble
+++ b/test/integration/scripts/.sti/bin/assemble
@@ -3,6 +3,10 @@
 cp -Rf /tmp/src /sti-fake/
 touch /sti-fake/assemble-invoked
 
+if [ -f /tmp/secret ]; then
+  grep -q secret /tmp/secret && touch /sti-fake/secret-delivered
+fi
+
 if [ -e /tmp/artifacts/save-artifacts-invoked ]; then
   touch /sti-fake/save-artifacts-invoked
 fi


### PR DESCRIPTION
Trello: https://trello.com/c/m5bPxwh4/643-8-allow-to-consume-secrets-in-builds

How this works?

```console
$ echo supersecretstuff > /tmp/foo/secret
$ s2i build -p never --loglevel=5 --inject /tmp/foo:/tmp/bar \
  file://${GOPATH}/src/github.com/openshift/sti-ruby/2.2/test/rack-test-app \
  centos/ruby-22-centos7 testapp
```

What will happen is that the content of `/tmp/foo` folder will get injected (copied) into the container where the `assemble` script runs into the `/tmp/bar` directory. Assemble script can then read the "secret" file from there. The `UploadToContainer` approach allows is to copy any file into any arbitrary location in the container, which is great, because you can replace any file in container (or write to any directory)...

The drawback of this solution is that the file that is copied is owned by `root` and thus we can't erase it entirely, but we can instead `truncate` it ;-) I think, personally, that it is enough (we can add shred if we want to be pedant)