### PR TITLE
Add rebase-to-origin.sh script

### DIFF
--- a/hack/rebase-to-origin.sh
+++ b/hack/rebase-to-origin.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+#
+# This script will create a rebase commit in the OpenShift Origin GIT repository
+# based on the current HEAD.
+#
+# NOTE: Make sure all your changes are committed and there are no junk files
+#       present in the pkg/ folder.
+#
+
+# Exclude these packages from source-to-image explicitely
+exclude_pkgs=(
+  pkg/cmd
+  pkg/config
+  pkg/create
+  pkg/run
+  pkg/test
+  pkg/version
+)
+
+s2i_dir=$GOPATH/src/github.com/openshift/source-to-image
+origin_dir=$GOPATH/src/github.com/openshift/origin
+origin_s2i_godep_dir=${origin_dir}/Godeps/_workspace/src/github.com/openshift/source-to-image
+s2i_ref=$(cd ${s2i_dir} && git rev-parse --verify HEAD)
+s2i_short_ref=$(cd ${s2i_dir} && git rev-parse --short HEAD)
+s2i_godeps_ref=$(grep -m2 -A2 "openshift/source-to-image" ${origin_dir}/Godeps/Godeps.json | \
+  grep Rev | cut -d ':' -f2 | sed -e 's/"//g' | sed -e 's/^[[:space:]]*//')
+
+pushd "${origin_dir}" >/dev/null
+  git checkout -b "s2i-${s2i_short_ref}-bump"
+  rm -rf "${origin_s2i_godep_dir}/*"
+  cp -R ${s2i_dir}/pkg ${origin_s2i_godep_dir}/.
+
+  # Remove all test files
+  find ${origin_s2i_godep_dir} -type f -name "*_test.go" -exec rm -f {} \;
+
+  # Remove all explicitely excluded packages
+  for pkg in "${exclude_pkgs[@]}"; do
+    rm -rf "${origin_s2i_godep_dir}/${pkg}"
+  done
+
+  # Bump the origin Godeps.json file
+  sed -i '' "s/${s2i_godeps_ref}/${s2i_ref}/g" ${origin_dir}/Godeps/Godeps.json
+
+  # Make a commit with proper message
+  git add Godeps && git commit -m "bump(github.com/openshift/source-to-image): ${s2i_ref}"
+popd


### PR DESCRIPTION
Tired of manual rebase to origin? Try this handy script :-)

This script assumes that the "origin" is cloned into $GOPATH/src/github.com/openshift/origin.
This script will create a new branch, so make sure the "origin" HEAD is the latest master.
After you invoke this script, the branch and the commit will be created with proper commit message, ready to push and create a PR from it.