### PR TITLE
Fail the build when destinationDir does not exists during injection

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -452,6 +452,8 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 	// If there are injections specified, override the original assemble script
 	// and wait till all injections are uploaded into the container that runs the
 	// assemble script.
+	injectionComplete := make(chan struct{})
+	var injectionError error
 	if len(config.Injections) > 0 && command == api.Assemble {
 		workdir, err := b.docker.GetImageWorkdir(config.BuilderImage)
 		if err != nil {
@@ -467,22 +469,26 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 			return err
 		}
 		defer os.Remove(rmScript)
-		glog.V(5).Infof("Waiting for injected files to be copied into assemble container...")
 		opts.CommandOverrides = func(cmd string) string {
 			return fmt.Sprintf("while [ ! -f %q ]; do sleep 0.5; done; %s; result=$?; source %[1]s; exit $result",
 				"/tmp/rm-injections", cmd)
 		}
 		originalOnStart := opts.OnStart
 		opts.OnStart = func(containerID string) error {
+			defer close(injectionComplete)
 			if err != nil {
+				injectionError = err
 				return err
 			}
+			glog.V(2).Info("starting the injections uploading ...")
 			for _, s := range config.Injections {
 				if err := b.docker.UploadToContainer(s.SourcePath, s.DestinationDir, containerID); err != nil {
+					injectionError = util.HandleInjectionError(s, err)
 					return err
 				}
 			}
 			if err := b.docker.UploadToContainer(rmScript, "/tmp/rm-injections", containerID); err != nil {
+				injectionError = util.HandleInjectionError(api.InjectPath{SourcePath: rmScript, DestinationDir: "/tmp/rm-injections"}, err)
 				return err
 			}
 			if originalOnStart != nil {
@@ -490,16 +496,25 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 			}
 			return nil
 		}
+	} else {
+		close(injectionComplete)
 	}
 
 	if !config.LayeredBuild {
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		uploadDir := filepath.Join(config.WorkingDir, "upload")
-
 		// TODO: be able to pass a stream directly to the Docker build to avoid the double temp hit
 		r, w := io.Pipe()
 		go func() {
+			// Wait for the injections to complete and check the error. Do not start
+			// streaming the sources when the injection failed.
+			<-injectionComplete
+			if injectionError != nil {
+				wg.Done()
+				return
+			}
+			glog.V(2).Info("starting the source uploading ...")
 			var err error
 			defer func() {
 				w.CloseWithError(err)

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -88,3 +88,17 @@ func CreateInjectedFilesRemovalScript(files []string, scriptName string) (string
 	err = ioutil.WriteFile(f.Name(), []byte(rmScript), 0700)
 	return f.Name(), err
 }
+
+// HandleInjectionError handles the error caused by injection and provide
+// reasonable suggestion to users.
+func HandleInjectionError(p api.InjectPath, err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "no such file or directory") {
+		glog.Errorf("The destination directory for %q injection must exist in container (%q)", p.SourcePath, p.DestinationDir)
+		return err
+	}
+	glog.Errorf("Error occured during injecting %q to %q: %v", p.SourcePath, p.DestinationDir, err)
+	return err
+}


### PR DESCRIPTION
Fixes: https://github.com/openshift/source-to-image/issues/397

Thanks to @php-coder for debugging this problem! Can you please review this?

This will basically stop the build when the injection fails. It also provides 'better' error to user:

```console
E0128 09:52:23.853183 09625 injection.go:99] The destination directory for "/data/src/github.com/openshift/source-to-image/docs" injection must exists in container ("/root/foo")
I0128 09:52:24.776407 09625 main.go:326] An error occurred: API error (404): lstat /var/lib/docker/devicemapper/mnt/664dc416e71434fab5fae2324fdcc6125c141d3643b691442a250788b064e243/rootfs/root/foo: no such file or directory
```