### PR TITLE
Misc improvements

### DIFF
--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -74,7 +74,7 @@ func LoadAndGetImageRegistryAuth(dockerCfg io.Reader, imageName string) client.A
 	return GetImageRegistryAuth(auths, imageName)
 }
 
-// StreamContainerIO takes data from the Reader and redirects to the log functin (typically we pass in
+// StreamContainerIO takes data from the Reader and redirects to the log function (typically we pass in
 // glog.Error for stderr and glog.Info for stdout
 func StreamContainerIO(errStream io.Reader, errOutput *string, log func(...interface{})) {
 	scanner := bufio.NewReader(errStream)

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -53,6 +53,9 @@ func (h *fs) ReadDir(path string) ([]os.FileInfo, error) {
 
 // Chmod sets the file mode
 func (h *fs) Chmod(file string, mode os.FileMode) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	return os.Chmod(file, mode)
 }
 
@@ -113,10 +116,7 @@ func (h *fs) Copy(source string, dest string) (err error) {
 		return err
 	}
 
-	if runtime.GOOS == "windows" {
-		return
-	}
-	return os.Chmod(dest, sourceinfo.Mode())
+	return h.Chmod(dest, sourceinfo.Mode())
 }
 
 // CopyContents copies the content of the source directory to a destination
@@ -164,7 +164,7 @@ func (h *fs) RemoveDirectory(dir string) error {
 
 // CreateWorkingDirectory creates a directory to be used for STI
 func (h *fs) CreateWorkingDirectory() (directory string, err error) {
-	directory, err = ioutil.TempDir("", "sti")
+	directory, err = ioutil.TempDir("", "s2i")
 	if err != nil {
 		return "", errors.NewWorkDirError(directory, err)
 	}


### PR DESCRIPTION
Misc minor improvements that I've made during working on #397:
- `fs.Chmod()`: don't try to change file mode on Windows
- `fs.CreateWorkingDirectory()`: change prefix of the temp dir from sti to s2i
- `tar.StreamDirAsTar,StreamFileAsTar()`: don't try to change file mode on Windows
- `tar.CreateTarStreamWithLogging()`: don't swallow errors
- `tar.CreateTarStreamWithLogging()`: quote file names in error message
- `util.StreamContainerIO()`: fix typo in godoc

@mfojtik PTAL