### PR TITLE
Deprecate .sti/environment

### DIFF
--- a/docs/debugging-s2i.md
+++ b/docs/debugging-s2i.md
@@ -40,7 +40,7 @@ If you are passing in environment variables with the -e option from the command 
        	 I0519 14:20:51.410089 17228 util.go:34] Using my@cred.sk credentials for pulling openshift/ruby-20-centos7
      	 I0519 14:20:51.410222 17228 main.go:239] An error occurred: malformed env string: some-other-repo'
 
-To deal with this behavior, s2i by default will look for environment variables in the file `.sti/environment` in your source repository.  You can also point to a separate file with environment variable settings with the -E option.
+To deal with this behavior, s2i by default will look for environment variables in the file `.s2i/environment` in your source repository.  You can also point to a separate file with environment variable settings with the -E option.
 With both approaches, leveraging a file instead of the command line allows for the values of environment variable to contain commas.  Environment variable processing is described in the [README](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image) as well.
 
 With the above example, whichever file you leverage for environment variables would have this line:

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -266,7 +266,7 @@ func (b *STI) PostExecute(containerID, location string) error {
 
 	env, err := scripts.GetEnvironment(b.config)
 	if err != nil {
-		glog.V(1).Infof("No .sti/environment provided (%v)", err)
+		glog.V(1).Infof("No user environment provided (%v)", err)
 	}
 
 	buildEnv := append(scripts.ConvertEnvironment(env), b.generateConfigEnv()...)
@@ -413,7 +413,7 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 
 	env, err := scripts.GetEnvironment(config)
 	if err != nil {
-		glog.V(1).Infof("No .sti/environment provided (%v)", err)
+		glog.V(1).Infof("No user environment provided (%v)", err)
 	}
 
 	buildEnv := append(scripts.ConvertEnvironment(env), b.generateConfigEnv()...)

--- a/pkg/scripts/environment.go
+++ b/pkg/scripts/environment.go
@@ -18,30 +18,22 @@ type Environment struct {
 	Value string
 }
 
-// getEnvPath returns prefix/environment path.
-func getEnvPath(config *api.Config, prefix string) (string, error) {
-	envPath := filepath.Join(config.WorkingDir, api.Source, prefix, api.Environment)
-	if _, err := os.Stat(envPath); os.IsNotExist(err) {
-		return "", errors.New("no environment file found in application sources")
-	}
-	return envPath, nil
-}
-
 // GetEnvironment gets the .s2i/environment file located in the sources and
 // parse it into []environment
 func GetEnvironment(config *api.Config) ([]Environment, error) {
-	envPath, err := getEnvPath(config, ".s2i")
-	if err != nil {
-		envPath, err = getEnvPath(config, ".sti")
-		if err != nil {
-			return nil, err
+	envPath := filepath.Join(config.WorkingDir, api.Source, ".s2i", api.Environment)
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		// TODO: Remove this when the '.sti/environment' is deprecated.
+		envPath = filepath.Join(config.WorkingDir, api.Source, ".sti", api.Environment)
+		if _, err := os.Stat(envPath); os.IsNotExist(err) {
+			return nil, errors.New("no environment file found in application sources")
 		}
 		glog.Infof("DEPRECATED: Use .s2i/environment instead of .sti/environment")
 	}
 
 	f, err := os.Open(envPath)
 	if err != nil {
-		return nil, errors.New("unable to read environment file")
+		return nil, errors.New("unable to read custom environment file")
 	}
 	defer f.Close()
 
@@ -62,10 +54,10 @@ func GetEnvironment(config *api.Config) ([]Environment, error) {
 			Name:  strings.TrimSpace(parts[0]),
 			Value: strings.TrimSpace(parts[1]),
 		}
-		glog.V(1).Infof("Setting '%s' to '%s'", e.Name, e.Value)
 		result = append(result, e)
 	}
 
+	glog.Infof("Setting %d environment variables provided by environment file in sources", len(result))
 	return result, scanner.Err()
 }
 


### PR DESCRIPTION
@bparees FYI

This is a leftover from deprecating the `.sti` in `api.ScriptSource`. Also I'm adding glog.Infof() here because I think seeing that the environment of the build is going to change based on provided file is important to user to confirm the file is actually picked up and the env vars are used.