### PR TITLE
Remove custom SIGQUIT handler

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -56,7 +56,6 @@ $ s2i build git://github.com/openshift/ruby-hello-world centos/ruby-22-centos7 h
 $ s2i build . centos/ruby-22-centos7 hello-world-app
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			go cmdutil.InstallDumpOnSignal()
 			if glog.V(1) {
 				glog.Infof("Running S2I version %q\n", version.Get())
 			}

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -2,38 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/spf13/cobra"
 )
-
-// InstallDumpOnSignal installs a handler for SIGQUIT signal that you can send
-// to a s2i process that is stuck. In that case a go routine dump should be
-// returned which can help debugging.
-func InstallDumpOnSignal() {
-	for {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGQUIT)
-		buf := make([]byte, 1<<20)
-		for {
-			<-sigs
-			runtime.Stack(buf, true)
-			if file, err := ioutil.TempFile(os.TempDir(), "sti_dump"); err == nil {
-				defer file.Close()
-				file.Write(buf)
-			}
-			glog.Infof("=== received SIGQUIT ===\n*** goroutine dump...\n%s\n*** end\n", buf)
-		}
-	}
-}
 
 // AddCommonFlags adds the common flags for usage, build and rebuild commands
 func AddCommonFlags(c *cobra.Command, cfg *api.Config) {


### PR DESCRIPTION
Go prints a stack trace of all goroutines by default on SIGQUIT, except those related to the runtime.
To include all goroutines, set GOTRACEBACK=2 or GOTRACEBACK=crash.

This custom handler suppresses Go's default behavior.

http://stackoverflow.com/a/35290196/4804690