### PR TITLE
Add support for custom tag for incremental builds

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -107,6 +107,10 @@ type Config struct {
 	// Incremental describes whether to try to perform incremental build.
 	Incremental bool
 
+	// IncrementalFromTag sets an alternative image tag to look for existing
+	// artifacts. Tag is used by default if this is not set.
+	IncrementalFromTag string
+
 	// RemovePreviousImage describes if previous image should be removed after successful build.
 	// This applies only to incremental builds.
 	RemovePreviousImage bool

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -344,9 +344,14 @@ func (b *STI) Exists(config *api.Config) bool {
 		policy = api.DefaultPreviousImagePullPolicy
 	}
 
-	result, err := dockerpkg.PullImage(config.Tag, b.incrementalDocker, policy, false)
+	tag := config.IncrementalFromTag
+	if len(tag) == 0 {
+		tag = config.Tag
+	}
+
+	result, err := dockerpkg.PullImage(tag, b.incrementalDocker, policy, false)
 	if err != nil {
-		glog.V(2).Infof("Unable to pull previously build %q image: %v", config.Tag, err)
+		glog.V(2).Infof("Unable to pull previously built image %q: %v", tag, err)
 		return false
 	}
 
@@ -361,7 +366,10 @@ func (b *STI) Save(config *api.Config) (err error) {
 		return err
 	}
 
-	image := config.Tag
+	image := config.IncrementalFromTag
+	if len(image) == 0 {
+		image = config.Tag
+	}
 	outReader, outWriter := io.Pipe()
 	errReader, errWriter := io.Pipe()
 	defer errReader.Close()


### PR DESCRIPTION
This allows to take artifacts from an image with a tag different than the output tag.

The default behavior is still to use the same tags.

This is needed to fix a regression in incremental builds OpenShift: https://github.com/openshift/origin/issues/7708