### PR TITLE
Defer closing all ends of pipe

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -152,9 +152,7 @@ func (b *STI) Build(config *api.Config) (*api.Result, error) {
 	if b.incremental {
 		if err := b.artifacts.Save(config); err != nil {
 			glog.Warningf("Clean build will be performed because of error saving previous build artifacts")
-			if glog.V(2) {
-				glog.Infof("ERROR: %v", err)
-			}
+			glog.V(2).Infof("ERROR: %v", err)
 		}
 	}
 
@@ -371,12 +369,13 @@ func (b *STI) Save(config *api.Config) (err error) {
 		image = config.Tag
 	}
 	outReader, outWriter := io.Pipe()
+	defer outReader.Close()
+	defer outWriter.Close()
 	errReader, errWriter := io.Pipe()
 	defer errReader.Close()
 	defer errWriter.Close()
 	glog.V(1).Infof("Saving build artifacts from image %s to path %s", image, artifactTmpDir)
 	extractFunc := func(string) error {
-		defer outReader.Close()
 		return b.tar.ExtractTarStream(artifactTmpDir, outReader)
 	}
 


### PR DESCRIPTION
- Let the function that created the pipe arrange freeing resources
  (we shall not rely on extractFunc being executed).
- Remove unnecessary if clause.