### PR TITLE
Allowing dropping capabilities when running a container

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -178,6 +178,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
 	buildCmd.Flags().VarP(&(cfg.AllowedUIDs), "allowed-uids", "u", "Specify a range of allowed user ids for the builder image")
 	buildCmd.Flags().VarP(&(cfg.Injections), "inject", "i", "Specify a list of directories to inject into the assemble container")
+	buildCmd.Flags().StringSliceVar(&(cfg.DropCapabilities), "cap-drop", []string{}, "Specify a comma-separated list of capabilities to drop when running Docker containers")
 	buildCmd.Flags().StringVarP(&(oldDestination), "location", "l", "",
 		"DEPRECATED: Specify a destination location for untar operation")
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -175,6 +175,9 @@ type Config struct {
 	// CGroupLimits describes the cgroups limits that will be applied to any containers
 	// run by s2i.
 	CGroupLimits *CGroupLimits
+
+	// DropCapabilities contains a list of capabilities to drop when executing containers
+	DropCapabilities []string
 }
 
 type CGroupLimits struct {
@@ -343,7 +346,7 @@ func (p *PullPolicy) Set(v string) error {
 	case "if-not-present":
 		*p = PullIfNotPresent
 	default:
-		return fmt.Errorf("invalid value %q, valid values are: always, never or if-not-present")
+		return fmt.Errorf("invalid value %q, valid values are: always, never or if-not-present", v)
 	}
 	return nil
 }

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -403,6 +403,7 @@ func (b *STI) Save(config *api.Config) (err error) {
 		OnStart:         extractFunc,
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
+		CapDrop:         config.DropCapabilities,
 	}
 
 	go dockerpkg.StreamContainerIO(errReader, nil, glog.Error)
@@ -454,6 +455,7 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 		PostExec:        b.postExecutor,
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
+		CapDrop:         config.DropCapabilities,
 	}
 
 	// If there are injections specified, override the original assemble script

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -123,6 +123,7 @@ type RunContainerOptions struct {
 	NetworkMode      string
 	User             string
 	CGroupLimits     *api.CGroupLimits
+	CapDrop          []string
 }
 
 // CommitContainerOptions are options passed in to the CommitContainer method
@@ -611,6 +612,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) (err error) {
 		ccopts.HostConfig.CPUQuota = opts.CGroupLimits.CPUQuota
 		ccopts.HostConfig.CPUPeriod = opts.CGroupLimits.CPUPeriod
 	}
+	ccopts.HostConfig.CapDrop = opts.CapDrop
 	glog.V(2).Infof("Creating container %s using config: %+v, hostconfig: %+v", ccopts.Name, ccopts.Config, ccopts.HostConfig)
 	container, err := d.client.CreateContainer(ccopts)
 	if err != nil {

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -192,8 +192,12 @@ func PullImage(name string, d Docker, policy api.PullPolicy, force bool) (*PullR
 	return &PullResult{Image: image, OnBuild: d.IsImageOnBuild(name)}, err
 }
 
-// CheckAllowedUser checks if the Docker image contains allowed users
-// FIXME: @cswong this need better godoc
+// CheckAllowedUser retrieves the user for a Docker image and checks that user against
+// an allowed range of uids.
+// - If the range of users is not empty, then the user on the Docker image needs to be a numeric user
+// - The user's uid must be contained by the range(s) specified by the uids Rangelist
+// - If the image contains ONBUILD instructions and those instructions also contain a USER directive,
+//   then the user specified by that USER directive must meet the uid range criteria as well.
 func CheckAllowedUser(d Docker, imageName string, uids user.RangeList, isOnbuild bool) error {
 	if uids == nil || uids.Empty() {
 		return nil

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -51,6 +51,7 @@ func (b *DockerRunner) Run(config *api.Config) error {
 		Stderr:       errWriter,
 		TargetImage:  true,
 		CGroupLimits: config.CGroupLimits,
+		CapDrop:      config.DropCapabilities,
 	}
 
 	//NOTE, we've seen some Golang level deadlock issues with the streaming of cmd output to


### PR DESCRIPTION
Adds a flag to the s2i build command to allow specifying a set of capabilities to drop when executing a container.

Example:
```
s2i build --cap-drop=SETGID,SETUID https://github.com/myname/myrepo.git myco/builder:latest my-app
```