### PR TITLE
Close channel only after last send

### DIFF
--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -20,8 +20,10 @@ func (t *TimeoutError) Error() string {
 // time duration.
 func TimeoutAfter(t time.Duration, fn func() error) error {
 	c := make(chan error, 1)
-	defer close(c)
-	go func() { c <- fn() }()
+	go func() {
+		defer close(c)
+		c <- fn()
+	}()
 	select {
 	case err := <-c:
 		return err

--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -20,7 +20,8 @@ func (t *TimeoutError) Error() string {
 // time duration.
 func TimeoutAfter(t time.Duration, fn func() error) error {
 	c := make(chan error, 1)
-	go func() { defer close(c); c <- fn() }()
+	defer close(c)
+	go func() { c <- fn() }()
 	select {
 	case err := <-c:
 		return err


### PR DESCRIPTION
In case there is a time out, the goroutine would panic on sending on a
closed channel.


@bparees @mfojtik PTAL

@mfojtik here's the example you asked: http://play.golang.org/p/N5ANWaIdt6