### PR TITLE
Bump dockerclient to match version in origin

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -67,8 +67,7 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Comment": "0.2.1-860-g25bc220",
-			"Rev": "25bc220b299845ae5489fd19bf89c5278864b050"
+			"Rev": "0099401a7342ad77e71ca9f9a57c5e72fb80f6b2"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.3.3
   - 1.4.2
   - 1.5.3
-  - 1.6beta2
+  - 1.6rc2
   - tip
 env:
   - GOARCH=amd64 DOCKER_VERSION=1.7.1
@@ -13,6 +13,8 @@ env:
   - GOARCH=386   DOCKER_VERSION=1.8.3
   - GOARCH=amd64 DOCKER_VERSION=1.9.1
   - GOARCH=386   DOCKER_VERSION=1.9.1
+  - GOARCH=amd64 DOCKER_VERSION=1.10.0
+  - GOARCH=386   DOCKER_VERSION=1.10.0
 install:
   - make prepare_docker
 script:

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
@@ -50,6 +50,7 @@ Flavia Missi <flaviamissi@gmail.com>
 Francisco Souza <f@souza.cc>
 Grégoire Delattre <gregoire.delattre@gmail.com>
 Guillermo Álvarez Fernández <guillermo@cientifico.net>
+Harry Zhang <harryzhang@zju.edu.cn>
 He Simei <hesimei@zju.edu.cn>
 Ivan Mikushin <i.mikushin@gmail.com>
 James Bardin <jbardin@litl.com>
@@ -111,6 +112,7 @@ Summer Mousa <smousa@zenoss.com>
 Sunjin Lee <styner32@gmail.com>
 Tarsis Azevedo <tarsis@corp.globo.com>
 Tim Schindler <tim@catalyst-zero.com>
+Timothy St. Clair <tstclair@redhat.com>
 Tobi Knaup <tobi@mesosphere.io>
 Tom Wilkie <tom.wilkie@gmail.com>
 Tonic <tonicbupt@gmail.com>

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/Makefile
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/Makefile
@@ -41,7 +41,7 @@ prepare_docker:
 	sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 	echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
 	sudo apt-get update
-	sudo apt-get install docker-engine=$(DOCKER_VERSION)-0~$(shell lsb_release -cs) -y --force-yes
+	sudo apt-get install docker-engine=$(DOCKER_VERSION)-0~$(shell lsb_release -cs) -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
 pretest: lint vet fmtcheck
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
@@ -60,7 +60,8 @@ func NewAPIVersion(input string) (APIVersion, error) {
 	if !strings.Contains(input, ".") {
 		return nil, fmt.Errorf("Unable to parse version %q", input)
 	}
-	arr := strings.Split(input, ".")
+	raw := strings.Split(input, "-")
+	arr := strings.Split(raw[0], ".")
 	ret := make(APIVersion, len(arr))
 	var err error
 	for i, val := range arr {
@@ -586,7 +587,7 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "plain/text")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 	protocol := c.endpointURL.Scheme

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
@@ -510,6 +510,7 @@ type HostConfig struct {
 	BlkioWeight      int64                  `json:"BlkioWeight,omitempty" yaml:"BlkioWeight"`
 	Ulimits          []ULimit               `json:"Ulimits,omitempty" yaml:"Ulimits,omitempty"`
 	VolumeDriver     string                 `json:"VolumeDriver,omitempty" yaml:"VolumeDriver,omitempty"`
+	OomScoreAdj      int                    `json:"OomScoreAdj,omitempty" yaml:"OomScoreAdj,omitempty"`
 }
 
 // StartContainer starts a container, returning an error in case of failure.
@@ -638,6 +639,7 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 // See https://goo.gl/GNmLHb for more details.
 type Stats struct {
 	Read        time.Time               `json:"read,omitempty" yaml:"read,omitempty"`
+	Network     NetworkStats            `json:"network,omitempty" yaml:"network,omitempty"`
 	Networks    map[string]NetworkStats `json:"networks,omitempty" yaml:"networks,omitempty"`
 	MemoryStats struct {
 		Stats struct {
@@ -670,6 +672,8 @@ type Stats struct {
 			Pgfault                 uint64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
 			InactiveFile            uint64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
 			TotalPgpgin             uint64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
+			HierarchicalMemswLimit  uint64 `json:"hierarchical_memsw_limit,omitempty" yaml:"hierarchical_memsw_limit,omitempty"`
+			Swap                    uint64 `json:"swap,omitempty" yaml:"swap,omitempty"`
 		} `json:"stats,omitempty" yaml:"stats,omitempty"`
 		MaxUsage uint64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty"`
 		Usage    uint64 `json:"usage,omitempty" yaml:"usage,omitempty"`


### PR DESCRIPTION
I'm gonna need code that is in the version in origin and not in the old version we had here (`AttachToContainerNonBlocking`)

Sending as separate PR to not pollute the diff of #430 with all these changes.

@bparees ptal