### PR TITLE
Wait for signal in the same goroutine

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -508,15 +508,11 @@ func runContainerDockerRun(container *docker.Container, d *stiDocker, image stri
 	glog.Infof("\n\n\n\n\nThe image %s has been started in container %s as a result of the --run=true option.  The container's stdout/stderr will be redirected to this command's glog output to help you validate its behavior.  You can also inspect the container with docker commands if you like.  If the container is set up to stay running, you will have to Ctrl-C to exit this command, which should also stop the container %s.  This particular invocation attempts to run with the port mappings %+v \n\n\n\n\n", image, container.ID, container.ID, liveports)
 
 	signalChan := make(chan os.Signal, 1)
-	cleanupDone := make(chan bool)
 	signal.Notify(signalChan, os.Interrupt)
-	go func() {
-		for signal := range signalChan {
-			glog.V(2).Infof("\nReceived signal '%s', stopping services...\n", signal)
-			cleanupDone <- true
-		}
-	}()
-	<-cleanupDone
+
+	// Block until user sends SIGINT.
+	signal := <-signalChan
+	glog.V(2).Infof("\nReceived signal '%s', stopping services...\n", signal)
 }
 
 // this funtion simply abstracts out the first phase of attaching to the container that was originally in line with the RunContainer() method


### PR DESCRIPTION
No need to spawn a goroutine just to block waiting for it do be done.

Extracted this away from my other changes to make it easier to review / test the behavior.

@bparees @gabemontero could you guys have a look?

I checked this change with this command:

```console
$ s2i build https://github.com/bparees/incremental-app centos/ruby-22-centos7 incr-test --loglevel=5 --run
...
The image incr-test:latest has been started in container 4fc3f034a41c833f7339594caa526e61256883ed01d1f70b7a5c48f93ea67a5f as a result of the --run=true option.  The container's stdout/stderr will be redirected to this command's glog output to help you validate its behavior.  You can also inspect the container with docker commands if you like.  If the container is set up to stay running, you will have to Ctrl-C to exit this command, which should also stop the container 4fc3f034a41c833f7339594caa526e61256883ed01d1f70b7a5c48f93ea67a5f.  This particular invocation attempts to run with the port mappings 

Port Bindings:  
  Container Port:  8080
        Protocol:  tcp
        Public Host / Port Mappings:
            IP: 0.0.0.0 Port: 32771
 




I0317 20:48:21.790067 22540 util.go:91] You might consider adding 'puma' into your Gemfile.
E0317 20:48:22.840582 22540 util.go:91] [2016-03-17 20:48:22] INFO  WEBrick 1.3.1
E0317 20:48:22.840697 22540 util.go:91] [2016-03-17 20:48:22] INFO  ruby 2.2.2 (2015-04-13) [x86_64-linux]
E0317 20:48:22.842521 22540 util.go:91] [2016-03-17 20:48:22] INFO  WEBrick::HTTPServer#start: pid=1 port=8080
^CI0317 20:49:55.149013 22540 docker.go:515] 
Received signal 'interrupt', stopping services...
```

(note: despite the name, not actually an incremental build)

The container was stopped/removed after Ctrl-C.