### PR TITLE
allow for no source URL (defer download to assemble script)

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -10,9 +10,6 @@ import (
 // ValidateConfig returns a list of error from validation.
 func ValidateConfig(config *api.Config) []ValidationError {
 	allErrs := []ValidationError{}
-	if len(config.Source) == 0 {
-		allErrs = append(allErrs, NewFieldRequired("source"))
-	}
 	if len(config.BuilderImage) == 0 {
 		allErrs = append(allErrs, NewFieldRequired("builderImage"))
 	}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -41,6 +41,16 @@ func TestValidation(t *testing.T) {
 			},
 			[]ValidationError{},
 		},
+		{
+			&api.Config{
+				Source:            "",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]ValidationError{},
+		},
 	}
 	for _, test := range testCases {
 		result := ValidateConfig(test.value)

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/docker"
 	stierr "github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/ignore"
+	"github.com/openshift/source-to-image/pkg/scm/empty"
 	"github.com/openshift/source-to-image/pkg/scm/file"
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/test"
@@ -150,6 +151,23 @@ func TestDefaultSource(t *testing.T) {
 		t.Errorf("Config.Source not set: %v", config.Source)
 	}
 	if _, ok := sti.source.(*file.File); !ok || sti.source == nil {
+		t.Errorf("Source interface not set: %#v", sti.source)
+	}
+}
+
+func TestEmptySource(t *testing.T) {
+	config := &api.Config{
+		Source:       "",
+		DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+	}
+	sti, err := New(config, build.Overrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Source != "" {
+		t.Errorf("Config.Source unexpectantly changed: %v", config.Source)
+	}
+	if _, ok := sti.source.(*empty.Noop); !ok || sti.source == nil {
 		t.Errorf("Source interface not set: %#v", sti.source)
 	}
 }

--- a/pkg/scm/empty/noop.go
+++ b/pkg/scm/empty/noop.go
@@ -1,0 +1,17 @@
+package empty
+
+import (
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+// Noop is for build configs with an empty Source definition, where
+// the assemble script is responsible for retrieving source
+type Noop struct {
+}
+
+func (n *Noop) Download(config *api.Config) (*api.SourceInfo, error) {
+	glog.V(1).Info("No source location defined (the assemble script is responsible for obtaining the source)")
+
+	return &api.SourceInfo{}, nil
+}

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/openshift/source-to-image/pkg/build"
+	"github.com/openshift/source-to-image/pkg/scm/empty"
 	"github.com/openshift/source-to-image/pkg/scm/file"
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/util"
@@ -15,6 +16,10 @@ import (
 // the sources from the repository.
 func DownloaderForSource(s string, forceCopy bool) (build.Downloader, string, error) {
 	glog.V(4).Infof("DownloadForSource %s", s)
+
+	if len(s) == 0 {
+		return &empty.Noop{}, s, nil
+	}
 
 	details, mods := git.ParseFile(s)
 	glog.V(4).Infof("return from ParseFile file exists %v proto specified %v use copy %v", details.FileExists, details.ProtoSpecified, details.UseCopy)

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -41,6 +41,8 @@ func TestDownloaderForSource(t *testing.T) {
 		"file://" + localDir:   "file.File",
 		"foo://github.com/bar": "error",
 		"./foo":                "error",
+		// Empty source string
+		"": "empty.Noop",
 	}
 
 	for s, expected := range tc {


### PR DESCRIPTION
@bparees PTAL

These are the source-to-image changes needed for build config with no inputs.

They stem from [this call in origin](https://github.com/openshift/origin/blob/master/pkg/build/builder/sti.go#L208) failing a source strategy build.

Also, I made this change *origin* only, and did not add any options to `s2i`.  The `s2i` user minimally still should point that command to a local directory with scripts.