### PR TITLE
Fix test messages

### DIFF
--- a/pkg/build/strategies/layered/layered_test.go
+++ b/pkg/build/strategies/layered/layered_test.go
@@ -61,7 +61,7 @@ func TestBuildOK(t *testing.T) {
 		t.Errorf("Expected LayeredBuild to be true!")
 	}
 	if m, _ := regexp.MatchString(`test/image-\d+`, l.config.BuilderImage); !m {
-		t.Errorf("Expected BuilderImage test/image-withnumbers, but got %s ", l.config.BuilderImage)
+		t.Errorf("Expected BuilderImage test/image-withnumbers, but got %s", l.config.BuilderImage)
 	}
 	// without config.Destination explicitly set, we should get /tmp/scripts for the scripts url
 	// assuming the assemble script we created above is off the working dir

--- a/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/pkg/build/strategies/onbuild/onbuild_test.go
@@ -2,7 +2,6 @@ package onbuild
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -48,15 +47,15 @@ func checkDockerfile(fs *test.FakeFileSystem, t *testing.T) {
 		t.Errorf("%v", fs.WriteFileError)
 	}
 	if fs.WriteFileName != "upload/src/Dockerfile" {
-		t.Errorf("Expected Dockerfile in 'upload/src/Dockerfile', got %v", fs.WriteFileName)
+		t.Errorf("Expected Dockerfile in 'upload/src/Dockerfile', got %q", fs.WriteFileName)
 	}
 	if !strings.Contains(fs.WriteFileContent, `ENTRYPOINT ["./run"]`) {
-		t.Errorf("The Dockerfile does not set correct entrypoint:\n %s\n", fs.WriteFileContent)
+		t.Errorf("The Dockerfile does not set correct entrypoint, file content:\n%s", fs.WriteFileContent)
 	}
 
 	buf := bytes.NewBuffer([]byte(fs.WriteFileContent))
 	if _, err := parser.Parse(buf); err != nil {
-		t.Errorf("cannot parse new Dockerfile: " + err.Error())
+		t.Errorf("cannot parse new Dockerfile: %v", err)
 	}
 
 }
@@ -102,7 +101,7 @@ func TestCreateDockerfileWithAssemble(t *testing.T) {
 	}
 	checkDockerfile(fakeFs, t)
 	if !strings.Contains(fakeFs.WriteFileContent, `RUN sh assemble`) {
-		t.Errorf("The Dockerfile does not run assemble:\n%s\n", fakeFs.WriteFileContent)
+		t.Errorf("The Dockerfile does not run assemble, file content:\n%s", fakeFs.WriteFileContent)
 	}
 }
 
@@ -128,5 +127,5 @@ func TestBuild(t *testing.T) {
 		t.Errorf("Expected successfull build, got: %v", result)
 	}
 	checkDockerfile(fakeFs, t)
-	fmt.Printf("result: %v\n", result)
+	t.Logf("result: %v", result)
 }

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -45,7 +45,7 @@ func TestIsImageInLocalRegistry(t *testing.T) {
 			t.Errorf("Test - %s: Expected error: %v. Got: %v", test, def.expectedError, err)
 		}
 		if def.docker.InspectImageName[0] != def.expectedImageName {
-			t.Errorf("Docker inspect called with unexpected image name: %s\n",
+			t.Errorf("Docker inspect called with unexpected image name: %s",
 				def.docker.InspectImageName)
 		}
 	}

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -25,15 +25,15 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 	// create working dir
 	workingDir, werr := util.NewFileSystem().CreateWorkingDirectory()
 	if werr != nil {
-		t.Errorf("problem allocating working dir %v \n", werr)
+		t.Errorf("problem allocating working dir: %v", werr)
 	} else {
-		t.Logf("working directory is %s \n", workingDir)
+		t.Logf("working directory is %q", workingDir)
 	}
 	defer func() {
 		// clean up test
 		cleanerr := os.RemoveAll(workingDir)
 		if cleanerr != nil {
-			t.Errorf("problem cleaning up %v \n", cleanerr)
+			t.Errorf("problem cleaning up: %v", cleanerr)
 		}
 	}()
 
@@ -43,32 +43,32 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 	dpath := filepath.Join(c.WorkingDir, "upload", "src")
 	derr := os.MkdirAll(dpath, 0777)
 	if derr != nil {
-		t.Errorf("Problem creating source repo dir %s with  %v \n", dpath, derr)
+		t.Errorf("Problem creating source repo dir %q: %v", dpath, derr)
 	}
 
 	c.WorkingSourceDir = dpath
-	t.Logf("working source dir %s \n", dpath)
+	t.Logf("working source dir %q", dpath)
 
 	// create s2iignore file
 	ipath := filepath.Join(dpath, api.IgnoreFile)
 	ifile, ierr := os.Create(ipath)
 	defer ifile.Close()
 	if ierr != nil {
-		t.Errorf("Problem creating .s2iignore at %s with  %v \n", ipath, ierr)
+		t.Errorf("Problem creating .s2iignore in %q: %v", ipath, ierr)
 	}
 
 	// write patterns to remove into s2ignore, but save ! exclusions
 	filesToIgnore := make(map[string]string)
 	for _, pattern := range patterns {
-		t.Logf("storing pattern %s \n", pattern)
+		t.Logf("storing pattern %q", pattern)
 		_, serr := ifile.WriteString(pattern)
 
 		if serr != nil {
-			t.Errorf("Problem setting .s2iignore %v \n", serr)
+			t.Errorf("Problem setting .s2iignore: %v", serr)
 		}
 		if strings.HasPrefix(pattern, "!") {
 			pattern = strings.Replace(pattern, "!", "", 1)
-			t.Logf("Noting ignore pattern  %s \n", pattern)
+			t.Logf("Noting ignore pattern %q", pattern)
 			filesToIgnore[pattern] = pattern
 		}
 	}
@@ -94,13 +94,13 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 		dirpath := filepath.Dir(fbpath)
 		derr := os.MkdirAll(dirpath, 0777)
 		if derr != nil && !os.IsExist(derr) {
-			t.Errorf("Problem creating subdirs %s with %v \n", dirpath, derr)
+			t.Errorf("Problem creating subdirs %q: %v", dirpath, derr)
 		}
-		t.Logf("Going to create file %s given supplied suffix %s \n", fbpath, fileToCreate)
+		t.Logf("Going to create file %q", fbpath)
 		fbfile, fberr := os.Create(fbpath)
 		defer fbfile.Close()
 		if fberr != nil {
-			t.Errorf("Problem creating test file %v \n", fberr)
+			t.Errorf("Problem creating test file: %v", fberr)
 		}
 	}
 
@@ -111,7 +111,7 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 	// check if filesToDel, minus ignores, are gone, and filesToKeep are still there
 	for _, fileToCheck := range filesToCreate {
 		fbpath := filepath.Join(dpath, fileToCheck)
-		t.Logf("Evaluating file %s from dir %s and file to check %s \n", fbpath, dpath, fileToCheck)
+		t.Logf("Evaluating file %q from dir %q and file to check %q", fbpath, dpath, fileToCheck)
 
 		// see if file still exists or not
 		ofile, oerr := os.Open(fbpath)
@@ -119,13 +119,13 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 		var fileExists bool
 		if oerr == nil {
 			fileExists = true
-			t.Logf("The file %s exists after Ignore was run \n", fbpath)
+			t.Logf("The file %q exists after Ignore was run", fbpath)
 		} else {
 			if os.IsNotExist(oerr) {
-				t.Logf("The file %s does not exist after Ignore was run \n", fbpath)
+				t.Logf("The file %q does not exist after Ignore was run", fbpath)
 				fileExists = false
 			} else {
-				t.Errorf("Could not verify existence of %s because of %v \n", fbpath, oerr)
+				t.Errorf("Could not verify existence of %q: %v", fbpath, oerr)
 			}
 		}
 
@@ -136,46 +136,36 @@ func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep 
 		// if file present, verify it is in ignore or keep list, and not in del list
 		if fileExists {
 			if iok {
-				t.Logf("validated ignored file is still present %s \n ", fileToCheck)
+				t.Logf("validated ignored file is still present: %q", fileToCheck)
 				continue
 			}
-
 			if kok {
-				t.Logf("validated file to keep is still present %s \n", fileToCheck)
+				t.Logf("validated file to keep is still present: %q", fileToCheck)
 				continue
 			}
-
 			if dok {
-				t.Errorf("file which was cited to be deleted by caller to runTest exists %s \n", fileToCheck)
+				t.Errorf("file which was cited to be deleted by caller to runTest exists: %q", fileToCheck)
 				continue
 			}
-
 			// if here, something unexpected
-			t.Errorf("file not in ignore / keep / del list  !?!?!?!?  %s \n", fileToCheck)
-
+			t.Errorf("file %q not in ignore / keep / del list !?!?!?!?", fileToCheck)
 		} else {
 			if dok {
-				t.Logf("file which should have been deleted is in fact gone %s \n", fileToCheck)
+				t.Logf("file which should have been deleted is in fact gone: %q", fileToCheck)
 				continue
 			}
-
 			if iok {
-				t.Errorf("file put into ignore list does not exist %s \n ", fileToCheck)
+				t.Errorf("file put into ignore list does not exist: %q", fileToCheck)
 				continue
 			}
-
 			if kok {
-				t.Errorf("file passed in with keep list does not exist %s \n", fileToCheck)
+				t.Errorf("file passed in with keep list does not exist: %q", fileToCheck)
 				continue
 			}
-
 			// if here, then something unexpected happened
-			t.Errorf("file not in ignore / keep / del list  !?!?!?!?  %s \n", fileToCheck)
-
+			t.Errorf("file %q not in ignore / keep / del list !?!?!?!?", fileToCheck)
 		}
-
 	}
-
 }
 
 func TestSingleIgnore(t *testing.T) {

--- a/pkg/scm/git/clone_test.go
+++ b/pkg/scm/git/clone_test.go
@@ -38,7 +38,7 @@ func TestCloneWithContext(t *testing.T) {
 		t.Errorf("Expected to remove the upload/tmp directory")
 	}
 	if !reflect.DeepEqual(cr.Args, []string{"checkout", "ref1"}) {
-		t.Errorf("Unexpected command arguments: %#v\n", cr.Args)
+		t.Errorf("Unexpected command arguments: %#v", cr.Args)
 	}
 }
 

--- a/pkg/scm/git/git_test.go
+++ b/pkg/scm/git/git_test.go
@@ -208,7 +208,7 @@ func TestMungeNoProtocolURL(t *testing.T) {
 	for scenario, test := range tests {
 		uri, err := url.Parse(scenario)
 		if err != nil {
-			t.Errorf("Could not parse url %s", scenario)
+			t.Errorf("Could not parse url %q", scenario)
 		}
 
 		err = gh.MungeNoProtocolURL(scenario, uri)
@@ -230,9 +230,22 @@ func TestMungeNoProtocolURL(t *testing.T) {
 			}
 		}
 		if !equal {
-			t.Errorf("For URL string %s, field by field check for scheme %v opaque %v host %v path %v rawq %v frag %v out user nil %v test user nil %v out scheme  %s out opaque %s out host %s out path %s  out raw query %s out frag %s", scenario,
-				uri.Scheme == test.Scheme, uri.Opaque == test.Opaque, uri.Host == test.Host, uri.Path == test.Path, uri.RawQuery == test.RawQuery,
-				uri.Fragment == test.Fragment, uri.User == nil, test.User == nil, uri.Scheme, uri.Opaque, uri.Host, uri.Path, uri.RawQuery, uri.Fragment)
+			t.Errorf(`URL string %q, field by field check:
+- Scheme: got %v, ok? %v
+- Opaque: got %v, ok? %v
+- Host: got %v, ok? %v
+- Path: got %v, ok? %v
+- RawQuery: got %v, ok? %v
+- Fragment: got %v, ok? %v
+- User: got %v`,
+				scenario,
+				uri.Scheme, uri.Scheme == test.Scheme,
+				uri.Opaque, uri.Opaque == test.Opaque,
+				uri.Host, uri.Host == test.Host,
+				uri.Path, uri.Path == test.Path,
+				uri.RawQuery, uri.RawQuery == test.RawQuery,
+				uri.Fragment, uri.Fragment == test.Fragment,
+				uri.User)
 		}
 	}
 }
@@ -249,13 +262,13 @@ func TestGitClone(t *testing.T) {
 	gh, ch := getGit()
 	err := gh.Clone("source1", "target1", api.CloneConfig{Quiet: true, Recursive: true})
 	if err != nil {
-		t.Errorf("Unexpected error returned from clone: %v\n", err)
+		t.Errorf("Unexpected error returned from clone: %v", err)
 	}
 	if ch.Name != "git" {
-		t.Errorf("Unexpected command name: %s\n", ch.Name)
+		t.Errorf("Unexpected command name: %q", ch.Name)
 	}
 	if !reflect.DeepEqual(ch.Args, []string{"clone", "--quiet", "--recursive", "source1", "target1"}) {
-		t.Errorf("Unexpected command arguments: %#v\n", ch.Args)
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
 	}
 }
 
@@ -265,7 +278,7 @@ func TestGitCloneError(t *testing.T) {
 	ch.Err = runErr
 	err := gh.Clone("source1", "target1", api.CloneConfig{})
 	if err != runErr {
-		t.Errorf("Unexpected error returned from clone: %v\n", err)
+		t.Errorf("Unexpected error returned from clone: %v", err)
 	}
 }
 
@@ -273,16 +286,16 @@ func TestGitCheckout(t *testing.T) {
 	gh, ch := getGit()
 	err := gh.Checkout("repo1", "ref1")
 	if err != nil {
-		t.Errorf("Unexpected error returned from checkout: %v\n", err)
+		t.Errorf("Unexpected error returned from checkout: %v", err)
 	}
 	if ch.Name != "git" {
-		t.Errorf("Unexpected command name: %s\n", ch.Name)
+		t.Errorf("Unexpected command name: %q", ch.Name)
 	}
 	if !reflect.DeepEqual(ch.Args, []string{"checkout", "ref1"}) {
-		t.Errorf("Unexpected command arguments: %#v\n", ch.Args)
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
 	}
 	if ch.Opts.Dir != "repo1" {
-		t.Errorf("Unexpected value in exec directory: %s\n", ch.Opts.Dir)
+		t.Errorf("Unexpected value in exec directory: %q", ch.Opts.Dir)
 	}
 }
 
@@ -292,6 +305,6 @@ func TestGitCheckoutError(t *testing.T) {
 	ch.Err = runErr
 	err := gh.Checkout("repo1", "ref1")
 	if err != runErr {
-		t.Errorf("Unexpected error returned from checkout: %v\n", err)
+		t.Errorf("Unexpected error returned from checkout: %v", err)
 	}
 }

--- a/pkg/scripts/install_test.go
+++ b/pkg/scripts/install_test.go
@@ -91,7 +91,7 @@ func TestInstallOptionalFromURL(t *testing.T) {
 			}
 		}
 		if !validURL {
-			t.Errorf("the script %q was downloaded from invalid URL (%+v), s, urls")
+			t.Errorf("the script %q was downloaded from invalid URL (%+v)", s, urls)
 		}
 	}
 }
@@ -141,7 +141,7 @@ func TestInstallRequiredFromDocker(t *testing.T) {
 			}
 		}
 		if !validURL {
-			t.Errorf("the script %q was downloaded from invalid URL (%+v), s, urls")
+			t.Errorf("the script %q was downloaded from invalid URL (%+v)", s, urls)
 		}
 	}
 }
@@ -176,7 +176,7 @@ func TestInstallRequiredFromSource(t *testing.T) {
 			}
 		}
 		if !validResultURL {
-			t.Errorf("expected %q has result URL "+sourcesRootAbbrev+".s2i/bin/script>, got %#v", s, result)
+			t.Errorf("expected %q has result URL %s.s2i/bin/script, got %#v", s, sourcesRootAbbrev, result)
 		}
 		chmodCalled := false
 		fs := config.fs.(*test.FakeFileSystem)

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -74,7 +74,7 @@ func verifyTarFile(t *testing.T, filename string, files []fileDesc, links []link
 	file, err := os.Open(filename)
 	defer file.Close()
 	if err != nil {
-		t.Fatalf("Cannot open tar file to verify: %s, %v\n", filename, err)
+		t.Fatalf("Cannot open tar file %q: %v", filename, err)
 	}
 	tr := tar.NewReader(file)
 	for {
@@ -83,38 +83,38 @@ func verifyTarFile(t *testing.T, filename string, files []fileDesc, links []link
 			break
 		}
 		if err != nil {
-			t.Fatalf("Error reading tar %s: %v\n", filename, err)
+			t.Fatalf("Error reading tar %q: %v", filename, err)
 		}
 		finfo := hdr.FileInfo()
 		if fd, ok := filesToVerify[hdr.Name]; ok {
 			delete(filesToVerify, hdr.Name)
 			if finfo.Mode().Perm() != fd.mode {
-				t.Errorf("File %s from tar %s does not match expected mode. Expected: %v, actual: %v\n",
+				t.Errorf("File %q from tar %q does not match expected mode. Expected: %v, actual: %v",
 					hdr.Name, filename, fd.mode, finfo.Mode().Perm())
 			}
 			if !fd.modifiedDate.IsZero() && finfo.ModTime().UTC() != fd.modifiedDate {
-				t.Errorf("File %s from tar %s does not match expected modified date. Expected: %v, actual: %v\n",
+				t.Errorf("File %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
 					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
 			}
 			fileBytes, err := ioutil.ReadAll(tr)
 			if err != nil {
-				t.Fatalf("Error reading tar %s: %v\n", filename, err)
+				t.Fatalf("Error reading tar %q: %v", filename, err)
 			}
 			fileContent := string(fileBytes)
 			if fileContent != fd.content {
-				t.Errorf("Content for file %s in tar %s doesn't match expected value. Expected: %s, Actual: %s",
+				t.Errorf("Content for file %q in tar %q doesn't match expected value. Expected: %q, Actual: %q",
 					finfo.Name(), filename, fd.content, fileContent)
 			}
 		} else if ld, ok := linksToVerify[hdr.Name]; ok {
 			delete(linksToVerify, hdr.Name)
 			if finfo.Mode()&os.ModeSymlink == 0 {
-				t.Errorf("Incorrect link %s", finfo.Name())
+				t.Errorf("Incorrect link %q", finfo.Name())
 			}
 			if hdr.Linkname != ld.fileName {
-				t.Errorf("Incorrect link location. Expected: %s, Actual %s", ld.fileName, hdr.Linkname)
+				t.Errorf("Incorrect link location. Expected: %q, Actual %q", ld.fileName, hdr.Linkname)
 			}
 		} else {
-			t.Errorf("Cannot find file %s from tar in files to verify.\n", hdr.Name)
+			t.Errorf("Cannot find file %q from tar in files to verify.", hdr.Name)
 		}
 	}
 
@@ -258,12 +258,12 @@ func verifyDirectory(t *testing.T, dir string, files []fileDesc) {
 			relpath := path[len(dir)+1:]
 			if fd, ok := filesToVerify[relpath]; ok {
 				if info.Mode() != fd.mode {
-					t.Errorf("File mode is not equal for %q. Expected: %v, Actual: %v\n",
+					t.Errorf("File mode is not equal for %q. Expected: %v, Actual: %v",
 						relpath, fd.mode, info.Mode())
 				}
 				// TODO: check modification time for symlinks when extractLink() will support it
 				if info.ModTime().UTC() != fd.modifiedDate && !isSymLink(fd.mode) {
-					t.Errorf("File modified date is not equal for %q. Expected: %v, Actual: %v\n",
+					t.Errorf("File modified date is not equal for %q. Expected: %v, Actual: %v",
 						relpath, fd.modifiedDate, info.ModTime())
 				}
 				contentBytes, err := ioutil.ReadFile(path)
@@ -273,7 +273,7 @@ func verifyDirectory(t *testing.T, dir string, files []fileDesc) {
 				}
 				content := string(contentBytes)
 				if content != fd.content {
-					t.Errorf("File content is not equal for %q. Expected: %s, Actual: %s\n",
+					t.Errorf("File content is not equal for %q. Expected: %q, Actual: %q",
 						relpath, fd.content, content)
 				}
 				if isSymLink(fd.mode) {
@@ -283,7 +283,7 @@ func verifyDirectory(t *testing.T, dir string, files []fileDesc) {
 						return err
 					}
 					if target != fd.target {
-						msg := "Symbolic link %q points to wrong path. Expected: %s, Actual: %s\n"
+						msg := "Symbolic link %q points to wrong path. Expected: %q, Actual: %q"
 						t.Errorf(msg, fd.name, fd.target, target)
 					}
 				}
@@ -309,7 +309,7 @@ func TestExtractTarStream(t *testing.T) {
 	reader, writer := io.Pipe()
 	destDir, err := ioutil.TempDir("", "testExtract")
 	if err != nil {
-		t.Fatalf("Cannot create temp directory: %v\n", err)
+		t.Fatalf("Cannot create temp directory: %v", err)
 	}
 	defer os.RemoveAll(destDir)
 	wg := sync.WaitGroup{}
@@ -335,7 +335,7 @@ func TestExtractTarStreamTimeout(t *testing.T) {
 	reader, writer := io.Pipe()
 	destDir, err := ioutil.TempDir("", "testExtract")
 	if err != nil {
-		t.Fatalf("Cannot create temp directory: %v\n", err)
+		t.Fatalf("Cannot create temp directory: %v", err)
 	}
 	defer os.RemoveAll(destDir)
 	wg := sync.WaitGroup{}
@@ -355,6 +355,6 @@ func TestExtractTarStreamTimeout(t *testing.T) {
 	wg.Wait()
 	err = <-extractError
 	if e, ok := err.(errors.Error); err == nil || (ok && e.ErrorCode != errors.TarTimeoutError) {
-		t.Errorf("Did not get the expected timeout error. err = %v\n", err)
+		t.Errorf("Did not get the expected timeout error. err = %v", err)
 	}
 }


### PR DESCRIPTION
- The majority of the changes in this commit is about removing redundant
  trailing '\n', since t.Logf & related methods automatically handle
  trailing new lines, and essentially ignore that extra line we're
  adding.
- Replace several usages of '%s' where '%q' would be more useful.
- Fix cases where the arguments to format the string were incorrectly
  part of the string itself, not arguments.