### PR TITLE
raise default docker timeout

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -48,7 +48,7 @@ const (
 
 	// DefaultDockerTimeout specifies a timeout for Docker API calls. When this
 	// timeout is reached, certain Docker API calls might error out.
-	DefaultDockerTimeout = 10 * time.Second
+	DefaultDockerTimeout = 20 * time.Second
 )
 
 // Docker is the interface between STI and the Docker client


### PR DESCRIPTION
@mfojtik i'm seeing us hit the 10s timeout in the push job here:
https://ci.openshift.redhat.com/jenkins/job/push_images_s2i/290/console

```
make test TARGET=centos7 VERSION=9.0 TAG_ON_SUCCESS=true
I0323 21:48:02.641485 09671 clone.go:32] Downloading "/tmp/images/wildfly-90/9.0/test/test-app" ...
I0323 21:48:02.665269 09671 install.go:236] Using "assemble" installed from "image:///usr/libexec/s2i/assemble"
I0323 21:48:02.665303 09671 install.go:236] Using "run" installed from "image:///usr/libexec/s2i/run"
I0323 21:48:02.665324 09671 install.go:236] Using "save-artifacts" installed from "image:///usr/libexec/s2i/save-artifacts"
E0323 21:48:12.675097 09671 main.go:336] An error occurred: calling the function timeout after 10s
```

so i think maybe we should raise the limit.  ptal.
