### PR TITLE
Fix deadlock condition

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -635,11 +635,13 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 		return err
 	}
 
-	// Run OnStart hook if defined.
+	// Run OnStart hook if defined. OnStart might block, so we run it in a
+	// new goroutine, and wait for it to be done later on.
+	onStartDone := make(chan error, 1)
 	if opts.OnStart != nil {
-		if err = opts.OnStart(container.ID); err != nil {
-			return err
-		}
+		go func() {
+			onStartDone <- opts.OnStart(container.ID)
+		}()
 	}
 
 	// We either block waiting for a user-originated SIGINT, or wait for the
@@ -660,6 +662,25 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 		}
 		if exitCode != 0 {
 			return errors.NewContainerError(container.Name, exitCode, "")
+		}
+	}
+
+	// FIXME: If Stdout or Stderr can be closed, close it to notify that
+	// there won't be any more writes. This is a hack to close the write
+	// half of a pipe so that the read half sees io.EOF.
+	// In particular, this is needed to eventually terminate code that runs
+	// on OnStart and blocks reading from the pipe.
+	if c, ok := opts.Stdout.(io.Closer); ok {
+		c.Close()
+	}
+	if c, ok := opts.Stderr.(io.Closer); ok {
+		c.Close()
+	}
+
+	// OnStart must be done before we move on.
+	if opts.OnStart != nil {
+		if err := <-onStartDone; err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
This is a quick on-spot fix, would be nice to actually rework the overall implementation to avoid this hackish solution.

The problem is that `STI.Save` (for saving artifacts) calls `RunContainer` with `opts.OnStart` set to a function that reads from the read half of a pipe, while the write half is set as the container stdout. Docker (go-dockerclient) won't close the container's output and error streams upon termination (expected behavior), so `OnStart` will never terminate, it will block forever waiting for more data to be read.

With `OnStart` blocked, `RunContainer` is blocked, and `STI.Save` never returns, thus the deferred call to close the pipe halves is never executed, thus the deadlock.

@bparees this is what we're all waiting for these days, it fixes the hang we were seeing with Graham's example:

```console
$ s2i build https://github.com/GrahamDumpleton/wheelhouse-demo grahamdumpleton/warp0-debian8-python27 wheelhouse-demo --incremental
I0324 10:08:38.527938 14986 clone.go:32] Downloading "https://github.com/GrahamDumpleton/wheelhouse-demo" ...
I0324 10:08:39.881757 14986 install.go:236] Using "assemble" installed from "image:///usr/local/s2i/bin/assemble"
I0324 10:08:39.881947 14986 install.go:236] Using "run" installed from "image:///usr/local/s2i/bin/run"
I0324 10:08:39.881973 14986 install.go:236] Using "save-artifacts" installed from "<source-dir>/.s2i/bin/save-artifacts"
E0324 10:08:41.161190 14986 util.go:91]  -----> Running save-artifacts
---> Installing application source
---> Building application from source
-----> Running /opt/warpdrive/.warpdrive/action_hooks/pre-build
...
```

~~Without this PR, the last message we see is `-----> Running save-artifacts` and `s2i` hangs forever.~~

**UPDATE**: actually, the deadlock condition was only revealed after some code refactoring in a private branch. The observed behavior in current master is this:

```console
$ s2i build https://github.com/GrahamDumpleton/wheelhouse-demo grahamdumpleton/warp0-debian8-python27 wheelhouse-demo --incremental
I0324 10:36:35.707182 16756 clone.go:32] Downloading "https://github.com/GrahamDumpleton/wheelhouse-demo" ...
I0324 10:36:36.828099 16756 install.go:236] Using "assemble" installed from "image:///usr/local/s2i/bin/assemble"
I0324 10:36:36.828917 16756 install.go:236] Using "run" installed from "image:///usr/local/s2i/bin/run"
I0324 10:36:36.828970 16756 install.go:236] Using "save-artifacts" installed from "<source-dir>/.s2i/bin/save-artifacts"
E0324 10:36:38.640226 16756 util.go:91]  -----> Running save-artifacts
W0324 10:37:08.594969 16756 sti.go:158] Clean build will be performed because of error saving previous build artifacts
E0324 10:37:08.595606 16756 tar.go:290] Error reading next tar header: io: read/write on closed pipe
---> Installing application source
---> Building application from source
```

After we see `-----> Running save-artifacts` it takes about 30 seconds before we see the next message with the error `Error reading next tar header: io: read/write on closed pipe`.

Why 30 seconds? Because that's the [default, per-chunk, timeout for processing the tar stream](https://github.com/openshift/source-to-image/blob/547b8abae42ebc502470f316a7b278ef2a873b08/pkg/tar/tar.go#L23).

Most likely, the very existence of that timeout might be related to the synchronization issue.