### PR TITLE
Add genbashcompletion sub-command

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -262,6 +263,20 @@ func newCmdCreate() *cobra.Command {
 	}
 }
 
+func newCmdGenBashCompletion(root *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:   "genbashcompletion",
+		Short: "Generate Bash completetion for the s2i command",
+		Long:  "Generate Bash completetion for the s2i command into standard output",
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: The latest version of cobra require to pass the io.Writer here.
+			var out bytes.Buffer
+			root.GenBashCompletion(&out)
+			fmt.Printf(out.String())
+		},
+	}
+}
+
 func newCmdUsage(cfg *api.Config) *cobra.Command {
 	oldScriptsFlag := ""
 	oldDestination := ""
@@ -372,6 +387,7 @@ func main() {
 		glog.Warning("sti binary is deprecated, use s2i instead")
 	}
 
+	stiCmd.AddCommand(newCmdGenBashCompletion(stiCmd))
 	err := stiCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/contrib/bash/s2i
+++ b/contrib/bash/s2i
@@ -1,0 +1,382 @@
+#!/bin/bash
+
+__debug()
+{
+    if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
+        echo "$*" >> "${BASH_COMP_DEBUG_FILE}"
+    fi
+}
+
+# Homebrew on Macs have version 1.3 of bash-completion which doesn't include
+# _init_completion. This is a very minimal version of that function.
+__my_init_completion()
+{
+    COMPREPLY=()
+    _get_comp_words_by_ref cur prev words cword
+}
+
+__index_of_word()
+{
+    local w word=$1
+    shift
+    index=0
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+        index=$((index+1))
+    done
+    index=-1
+}
+
+__contains_word()
+{
+    local w word=$1; shift
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+    done
+    return 1
+}
+
+__handle_reply()
+{
+    __debug "${FUNCNAME}"
+    case $cur in
+        -*)
+            compopt -o nospace
+            local allflags
+            if [ ${#must_have_one_flag[@]} -ne 0 ]; then
+                allflags=("${must_have_one_flag[@]}")
+            else
+                allflags=("${flags[*]} ${two_word_flags[*]}")
+            fi
+            COMPREPLY=( $(compgen -W "${allflags[*]}" -- "$cur") )
+            [[ $COMPREPLY == *= ]] || compopt +o nospace
+            return 0;
+            ;;
+    esac
+
+    # check if we are handling a flag with special work handling
+    local index
+    __index_of_word "${prev}" "${flags_with_completion[@]}"
+    if [[ ${index} -ge 0 ]]; then
+        ${flags_completion[${index}]}
+        return
+    fi
+
+    # we are parsing a flag and don't have a special handler, no completion
+    if [[ ${cur} != "${words[cword]}" ]]; then
+        return
+    fi
+
+    local completions
+    if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
+        completions=("${must_have_one_flag[@]}")
+    elif [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
+        completions=("${must_have_one_noun[@]}")
+    else
+        completions=("${commands[@]}")
+    fi
+    COMPREPLY=( $(compgen -W "${completions[*]}" -- "$cur") )
+
+    if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
+        declare -F __custom_func >/dev/null && __custom_func
+    fi
+}
+
+# The arguments should be in the form "ext1|ext2|extn"
+__handle_filename_extension_flag()
+{
+    local ext="$1"
+    _filedir "@(${ext})"
+}
+
+__handle_subdirs_in_dir_flag()
+{
+    local dir="$1"
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
+}
+
+__handle_flag()
+{
+    __debug "${FUNCNAME}: c is $c words[c] is ${words[c]}"
+
+    # if a command required a flag, and we found it, unset must_have_one_flag()
+    local flagname=${words[c]}
+    # if the word contained an =
+    if [[ ${words[c]} == *"="* ]]; then
+        flagname=${flagname%!=(MISSING)*} # strip everything after the =
+        flagname="${flagname}=" # but put the = back
+    fi
+    __debug "${FUNCNAME}: looking for ${flagname}"
+    if __contains_word "${flagname}" "${must_have_one_flag[@]}"; then
+        must_have_one_flag=()
+    fi
+
+    # skip the argument to a two word flag
+    if __contains_word "${words[c]}" "${two_word_flags[@]}"; then
+        c=$((c+1))
+        # if we are looking for a flags value, don't show commands
+        if [[ $c -eq $cword ]]; then
+            commands=()
+        fi
+    fi
+
+    # skip the flag itself
+    c=$((c+1))
+
+}
+
+__handle_noun()
+{
+    __debug "${FUNCNAME}: c is $c words[c] is ${words[c]}"
+
+    if __contains_word "${words[c]}" "${must_have_one_noun[@]}"; then
+        must_have_one_noun=()
+    fi
+
+    nouns+=("${words[c]}")
+    c=$((c+1))
+}
+
+__handle_command()
+{
+    __debug "${FUNCNAME}: c is $c words[c] is ${words[c]}"
+
+    local next_command
+    if [[ -n ${last_command} ]]; then
+        next_command="_${last_command}_${words[c]}"
+    else
+        next_command="_${words[c]}"
+    fi
+    c=$((c+1))
+    __debug "${FUNCNAME}: looking for ${next_command}"
+    declare -F $next_command >/dev/null && $next_command
+}
+
+__handle_word()
+{
+    if [[ $c -ge $cword ]]; then
+        __handle_reply
+	return
+    fi
+    __debug "${FUNCNAME}: c is $c words[c] is ${words[c]}"
+    if [[ "${words[c]}" == -* ]]; then
+	__handle_flag
+    elif __contains_word "${words[c]}" "${commands[@]}"; then
+        __handle_command
+    else
+        __handle_noun
+    fi
+    __handle_word
+}
+
+_s2i_version()
+{
+    last_command="s2i_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i_build()
+{
+    last_command="s2i_build"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--allowed-uids=")
+    two_word_flags+=("-u")
+    flags+=("--application-name=")
+    two_word_flags+=("-n")
+    flags+=("--assemble-user=")
+    flags+=("--callback-url=")
+    flags+=("--cap-drop=")
+    flags+=("--context-dir=")
+    flags+=("--copy")
+    flags+=("-c")
+    flags+=("--description=")
+    flags+=("--destination=")
+    two_word_flags+=("-d")
+    flags+=("--dockercfg-path=")
+    flags+=("--env=")
+    two_word_flags+=("-e")
+    flags+=("--environment-file=")
+    two_word_flags+=("-E")
+    flags+=("--force-pull")
+    flags+=("--incremental")
+    flags+=("--incremental-pull-policy=")
+    flags+=("--inject=")
+    two_word_flags+=("-i")
+    flags+=("--location=")
+    two_word_flags+=("-l")
+    flags+=("--pull-policy=")
+    two_word_flags+=("-p")
+    flags+=("--quiet")
+    flags+=("-q")
+    flags+=("--recursive")
+    flags+=("--ref=")
+    two_word_flags+=("-r")
+    flags+=("--rm")
+    flags+=("--run")
+    flags+=("--save-temp-dir")
+    flags+=("--scripts=")
+    flags+=("--scripts-url=")
+    two_word_flags+=("-s")
+    flags+=("--use-config")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i_rebuild()
+{
+    last_command="s2i_rebuild"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--callback-url=")
+    flags+=("--destination=")
+    two_word_flags+=("-d")
+    flags+=("--dockercfg-path=")
+    flags+=("--force-pull")
+    flags+=("--incremental")
+    flags+=("--incremental-pull-policy=")
+    flags+=("--pull-policy=")
+    two_word_flags+=("-p")
+    flags+=("--quiet")
+    flags+=("-q")
+    flags+=("--rm")
+    flags+=("--save-temp-dir")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i_usage()
+{
+    last_command="s2i_usage"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--callback-url=")
+    flags+=("--destination=")
+    two_word_flags+=("-d")
+    flags+=("--dockercfg-path=")
+    flags+=("--force-pull")
+    flags+=("--incremental")
+    flags+=("--incremental-pull-policy=")
+    flags+=("--location=")
+    two_word_flags+=("-l")
+    flags+=("--pull-policy=")
+    two_word_flags+=("-p")
+    flags+=("--quiet")
+    flags+=("-q")
+    flags+=("--rm")
+    flags+=("--save-temp-dir")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i_create()
+{
+    last_command="s2i_create"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i_genbashcompletion()
+{
+    last_command="s2i_genbashcompletion"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_s2i()
+{
+    last_command="s2i"
+    commands=()
+    commands+=("version")
+    commands+=("build")
+    commands+=("rebuild")
+    commands+=("usage")
+    commands+=("create")
+    commands+=("genbashcompletion")
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--ca=")
+    flags+=("--cert=")
+    flags+=("--key=")
+    flags+=("--loglevel=")
+    flags+=("--url=")
+    two_word_flags+=("-U")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+__start_s2i()
+{
+    local cur prev words cword
+    if declare -F _init_completions >/dev/null 2>&1; then
+        _init_completion -s || return
+    else
+        __my_init_completion || return
+    fi
+
+    local c=0
+    local flags=()
+    local two_word_flags=()
+    local flags_with_completion=()
+    local flags_completion=()
+    local commands=("s2i")
+    local must_have_one_flag=()
+    local must_have_one_noun=()
+    local last_command
+    local nouns=()
+
+    __handle_word
+}
+
+complete -F __start_s2i s2i
+# ex: ts=4 sw=4 et filetype=sh

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+STI_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+source "${STI_ROOT}/hack/common.sh"
+
+sti::build::build_binaries "$@"
+
+echo "+++ Updating Bash completion (${STI_ROOT}/contrib/bash/s2i)"
+${STI_LOCAL_BINPATH}/s2i genbashcompletion > ${STI_ROOT}/contrib/bash/s2i


### PR DESCRIPTION
Fixes: https://github.com/openshift/source-to-image/issues/415

@bparees PTAL

The usage here is to run:

`$ s2i genbashcompletion > completion_file.sh`

It is also possible to add `eval $(s2i genbashcompletion)` into `.bashrc` IMHO.
`EDIT:` Added generated completion per @soltysh request :-)