### PR TITLE
Add support for bind mounts

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -175,7 +175,8 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
 	buildCmd.Flags().VarP(&(cfg.AllowedUIDs), "allowed-uids", "u", "Specify a range of allowed user ids for the builder image")
-	buildCmd.Flags().VarP(&(cfg.Injections), "inject", "i", "Specify a list of directories to inject into the assemble container")
+	buildCmd.Flags().VarP(&(cfg.Injections), "inject", "i", "Specify a directory to inject into the assemble container")
+	buildCmd.Flags().VarP(&(cfg.BuildVolumes), "volume", "v", "Specify a volume to mount into the assemble container")
 	buildCmd.Flags().StringSliceVar(&(cfg.DropCapabilities), "cap-drop", []string{}, "Specify a comma-separated list of capabilities to drop when running Docker containers")
 	buildCmd.Flags().StringVarP(&(oldDestination), "location", "l", "",
 		"DEPRECATED: Specify a destination location for untar operation")

--- a/contrib/bash/s2i
+++ b/contrib/bash/s2i
@@ -234,6 +234,8 @@ _s2i_build()
     flags+=("--scripts-url=")
     two_word_flags+=("-s")
     flags+=("--use-config")
+    flags+=("--volume=")
+    two_word_flags+=("-v")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,8 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 | `-s (--scripts-url)`       | URL of S2I scripts (see [S2I Scripts](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts)) |
 | `--recursive`              | Perform recursive git clone when getting sources using git|
 | `-q (--quiet)`             | Operate quietly, suppressing all non-error output |
-| `--inject`                 | Inject the content of the specified directory into the path in the container that runs the assemble script |
+| `-i (--inject)`            | Inject the content of the specified directory into the path in the container that runs the assemble script |
+| `-v (--volume)`            | Bind mounts a local directory into the container that runs the assemble script|
 
 #### Context directory
 

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -68,9 +68,16 @@ func DescribeConfig(config *api.Config) string {
 		if len(config.Injections) > 0 {
 			result := []string{}
 			for _, i := range config.Injections {
-				result = append(result, fmt.Sprintf("%s->%s", i.SourcePath, i.DestinationDir))
+				result = append(result, fmt.Sprintf("%s->%s", i.Source, i.Destination))
 			}
 			fmt.Fprintf(out, "Injections:\t%s\n", strings.Join(result, ","))
+		}
+		if len(config.BuildVolumes) > 0 {
+			result := []string{}
+			for _, i := range config.BuildVolumes {
+				result = append(result, fmt.Sprintf("%s->%s", i.Source, i.Destination))
+			}
+			fmt.Fprintf(out, "Bind mounts:\t%s\n", strings.Join(result, ","))
 		}
 		return nil
 	})

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2,23 +2,23 @@ package api
 
 import "testing"
 
-func TestInjectionListSet(t *testing.T) {
-	table := map[string][]InjectPath{
-		"/test:":             {{SourcePath: "/test", DestinationDir: "."}},
-		"/test:/test":        {{SourcePath: "/test", DestinationDir: "/test"}},
-		"/test/foo:/etc/ssl": {{SourcePath: "/test/foo", DestinationDir: "/etc/ssl"}},
-		":/foo":              {{SourcePath: ".", DestinationDir: "/foo"}},
-		"/foo":               {{SourcePath: "/foo", DestinationDir: "."}},
-		":":                  {{SourcePath: ".", DestinationDir: "."}},
-		"/t est/foo:":        {{SourcePath: "/t est/foo", DestinationDir: "."}},
-		`"/test":"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
-		`'/test':"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
+func TestVolumeListSet(t *testing.T) {
+	table := map[string][]VolumeSpec{
+		"/test:":             {{Source: "/test", Destination: "."}},
+		"/test:/test":        {{Source: "/test", Destination: "/test"}},
+		"/test/foo:/etc/ssl": {{Source: "/test/foo", Destination: "/etc/ssl"}},
+		":/foo":              {{Source: ".", Destination: "/foo"}},
+		"/foo":               {{Source: "/foo", Destination: "."}},
+		":":                  {{Source: ".", Destination: "."}},
+		"/t est/foo:":        {{Source: "/t est/foo", Destination: "."}},
+		`"/test":"/foo"`:     {{Source: "/test", Destination: "/foo"}},
+		`'/test':"/foo"`:     {{Source: "/test", Destination: "/foo"}},
 		`"/te"st":"/foo"`:    {},
 		"/test/foo:/ss;ss":   {},
 		"/test;foo:/ssss":    {},
 	}
 	for v, expected := range table {
-		got := InjectionList{}
+		got := VolumeList{}
 		err := got.Set(v)
 		if len(expected) == 0 {
 			if err == nil {
@@ -33,7 +33,7 @@ func TestInjectionListSet(t *testing.T) {
 		for _, exp := range expected {
 			found := false
 			for _, g := range got {
-				if g.SourcePath == exp.SourcePath && g.DestinationDir == exp.DestinationDir {
+				if g.Source == exp.Source && g.Destination == exp.Destination {
 					found = true
 				}
 			}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -479,6 +479,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
 		CapDrop:         config.DropCapabilities,
+		Binds:           config.BuildVolumes.AsBinds(),
 	}
 
 	// If there are injections specified, override the original assemble script
@@ -514,13 +515,13 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 			}
 			glog.V(2).Info("starting the injections uploading ...")
 			for _, s := range config.Injections {
-				if err := builder.docker.UploadToContainer(s.SourcePath, s.DestinationDir, containerID); err != nil {
+				if err := builder.docker.UploadToContainer(s.Source, s.Destination, containerID); err != nil {
 					injectionError = util.HandleInjectionError(s, err)
 					return err
 				}
 			}
 			if err := builder.docker.UploadToContainer(rmScript, "/tmp/rm-injections", containerID); err != nil {
-				injectionError = util.HandleInjectionError(api.InjectPath{SourcePath: rmScript, DestinationDir: "/tmp/rm-injections"}, err)
+				injectionError = util.HandleInjectionError(api.VolumeSpec{Source: rmScript, Destination: "/tmp/rm-injections"}, err)
 				return err
 			}
 			if originalOnStart != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -129,6 +129,7 @@ type RunContainerOptions struct {
 	User             string
 	CGroupLimits     *api.CGroupLimits
 	CapDrop          []string
+	Binds            []string
 }
 
 // asDockerConfig converts a RunContainerOptions into a Config understood by the
@@ -151,6 +152,7 @@ func (rco RunContainerOptions) asDockerHostConfig() docker.HostConfig {
 		CapDrop:         rco.CapDrop,
 		PublishAllPorts: rco.TargetImage,
 		NetworkMode:     rco.NetworkMode,
+		Binds:           rco.Binds,
 	}
 	if rco.CGroupLimits != nil {
 		hostConfig.Memory = rco.CGroupLimits.MemoryLimitBytes

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -14,23 +14,23 @@ import (
 // FixInjectionsWithRelativePath fixes the injections that does not specify the
 // destination directory or the directory is relative to use the provided
 // working directory.
-func FixInjectionsWithRelativePath(workdir string, injections *api.InjectionList) {
+func FixInjectionsWithRelativePath(workdir string, injections *api.VolumeList) {
 	if len(*injections) == 0 {
 		return
 	}
-	newList := api.InjectionList{}
+	newList := api.VolumeList{}
 	for _, injection := range *injections {
 		changed := false
-		if filepath.Clean(injection.DestinationDir) == "." {
-			injection.DestinationDir = workdir
+		if filepath.Clean(injection.Destination) == "." {
+			injection.Destination = workdir
 			changed = true
 		}
-		if !filepath.IsAbs(injection.DestinationDir) {
-			injection.DestinationDir = filepath.Join(workdir, injection.DestinationDir)
+		if !filepath.IsAbs(injection.Destination) {
+			injection.Destination = filepath.Join(workdir, injection.Destination)
 			changed = true
 		}
 		if changed {
-			glog.V(5).Infof("Using %q as a destination for injecting %q", injection.DestinationDir, injection.SourcePath)
+			glog.V(5).Infof("Using %q as a destination for injecting %q", injection.Destination, injection.Source)
 		}
 		newList = append(newList, injection)
 	}
@@ -39,24 +39,20 @@ func FixInjectionsWithRelativePath(workdir string, injections *api.InjectionList
 
 // ExpandInjectedFiles returns a flat list of all files that are injected into a
 // container. All files from nested directories are returned in the list.
-func ExpandInjectedFiles(injections api.InjectionList) ([]string, error) {
+func ExpandInjectedFiles(injections api.VolumeList) ([]string, error) {
 	result := []string{}
 	for _, s := range injections {
-		info, err := os.Stat(s.SourcePath)
-		if err != nil {
+		if _, err := os.Stat(s.Source); err != nil {
 			return nil, err
 		}
-		if !info.IsDir() {
-			return nil, fmt.Errorf("the %q must be a valid directory", s.SourcePath)
-		}
-		err = filepath.Walk(s.SourcePath, func(path string, f os.FileInfo, err error) error {
+		err := filepath.Walk(s.Source, func(path string, f os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
 			if f.IsDir() {
 				return nil
 			}
-			newPath := filepath.Join(s.DestinationDir, strings.TrimPrefix(path, s.SourcePath))
+			newPath := filepath.Join(s.Destination, strings.TrimPrefix(path, s.Source))
 			result = append(result, newPath)
 			return nil
 		})
@@ -91,14 +87,14 @@ func CreateInjectedFilesRemovalScript(files []string, scriptName string) (string
 
 // HandleInjectionError handles the error caused by injection and provide
 // reasonable suggestion to users.
-func HandleInjectionError(p api.InjectPath, err error) error {
+func HandleInjectionError(p api.VolumeSpec, err error) error {
 	if err == nil {
 		return nil
 	}
 	if strings.Contains(err.Error(), "no such file or directory") {
-		glog.Errorf("The destination directory for %q injection must exist in container (%q)", p.SourcePath, p.DestinationDir)
+		glog.Errorf("The destination directory for %q injection must exist in container (%q)", p.Source, p.Destination)
 		return err
 	}
-	glog.Errorf("Error occured during injecting %q to %q: %v", p.SourcePath, p.DestinationDir, err)
+	glog.Errorf("Error occured during injecting %q to %q: %v", p.Source, p.Destination, err)
 	return err
 }

--- a/pkg/util/injection_test.go
+++ b/pkg/util/injection_test.go
@@ -44,7 +44,7 @@ func TestExpandInjectedFiles(t *testing.T) {
 		t.Errorf("Unable to create temp directory: %v", err)
 	}
 	defer os.RemoveAll(tmp)
-	list := api.InjectionList{{SourcePath: tmp, DestinationDir: "/foo"}}
+	list := api.VolumeList{{Source: tmp, Destination: "/foo"}}
 	f1, _ := ioutil.TempFile(tmp, "foo")
 	f2, _ := ioutil.TempFile(tmpNested, "bar")
 	files, err := ExpandInjectedFiles(list)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -378,7 +378,7 @@ func (i *integrationTest) exerciseInjectionBuild(tag, imageName string, injectio
 	if err != nil {
 		t.Errorf("Unable to write content to temporary injection file: %v", err)
 	}
-	injectionList := api.InjectionList{}
+	injectionList := api.VolumeList{}
 	for _, i := range injections {
 		injectionList.Set(i)
 	}


### PR DESCRIPTION
Fixes: https://github.com/openshift/source-to-image/issues/416

This PR add ability to define [bind mounts](https://docs.docker.com/engine/userguide/containers/dockervolumes/#adding-a-data-volume) for container where the assemble runs.

Note that this is different from "inject", because specifying a bind mount will replace the content of the directory inside the container, where "inject" will only add/overwrite the files.

One cool side-effect here is that you are able to "build" sources using S2I, but you don't have to care about the output image (allows to build jars, binary artifacts, etc...)

Example:

```console
$ s2i build --loglevel=5 -v $(pwd):/opt/app-root/src . centos/ruby-22-centos7 hello-world-app
```