### PR TITLE
Use cobra for parsing multiple env variables

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,7 +76,7 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 | `-d (--destination)`       | Location where the scripts and sources will be placed prior doing build (see [S2I Scripts](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts)) |
 | `--dockercfg-path`         | The path to the Docker configuration file |
 | `--incremental`            | Try to perform an incremental build |
-| `-e (--env)`               | Environment variables to be passed to the builder eg. `NAME=VALUE,NAME2=VALUE2,...` |
+| `-e (--env)`               | Environment variable to be passed to the builder eg. `NAME=VALUE` |
 | `-E (--environment-file)`  | Specify the path to the file with environment |
 | `--exclude`  | Regular expression for selecting files from the source tree to exclude from the build, where the default excludes the '.git' directory (see https://golang.org/pkg/regexp for syntax, but note that \"\" will be interpreted as allow all files and exclude no files) |
 | `--force-pull`             | Always pull the builder image, even if it is present locally (defaults to true) |
@@ -216,7 +216,7 @@ $ s2i usage <builder image> [flags]
 | Name                       | Description                                             |
 |:-------------------------- |:--------------------------------------------------------|
 | `-d (--destination)`       | Location where the scripts and sources will be placed prior invoking usage (see [S2I Scripts](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts))|
-| `-e (--env)`               | Environment variables passed to the builder eg. `NAME=VALUE,NAME2=VALUE2,...`) |
+| `-e (--env)`               | Environment variable passed to the builder eg. `NAME=VALUE`) |
 | `--force-pull`             | Always pull the builder image, even if it is present locally |
 | `--save-temp-dir`          | Save the working directory used for fetching scripts and sources |
 | `-s (--scripts-url)`       | URL of S2I scripts (see [Scripts URL](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts))|

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -102,13 +102,10 @@ func describeBuilderImage(config *api.Config, image string, out io.Writer) {
 	}
 }
 
-func printEnv(out io.Writer, env map[string]string) {
-	if len(env) == 0 {
-		return
-	}
+func printEnv(out io.Writer, env api.EnvironmentList) {
 	result := []string{}
-	for k, v := range env {
-		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	for _, e := range env {
+		result = append(result, strings.Join([]string{e.Name, e.Value}, "="))
 	}
 	fmt.Fprintf(out, "Environment:\t%s\n", strings.Join(result, ","))
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
 
 	"github.com/openshift/source-to-image/pkg/util/user"
 )
@@ -117,7 +118,7 @@ type Config struct {
 	RemovePreviousImage bool
 
 	// Environment is a map of environment variables to be passed to the image.
-	Environment map[string]string
+	Environment EnvironmentList
 
 	// EnvironmentFile provides the path to a file with list of environment
 	// variables.
@@ -198,6 +199,15 @@ type Config struct {
 	// the container for images that don't have a tar binary available.
 	DisableImplicitBuild bool
 }
+
+// EnvironmentSpec specifies a single environment variable.
+type EnvironmentSpec struct {
+	Name  string
+	Value string
+}
+
+// EnvironmentList contains list of environment variables.
+type EnvironmentList []EnvironmentSpec
 
 type ProxyConfig struct {
 	HTTPProxy  *url.URL
@@ -422,5 +432,35 @@ func (il *InjectionList) String() string {
 
 // Type implements the Type() function of pflags.Value interface.
 func (il *InjectionList) Type() string {
+	return "string"
+}
+
+// Set implements the Set() function of pflags.Value interface.
+func (e *EnvironmentList) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 || len(parts[0]) == 0 {
+		return fmt.Errorf("invalid environment format %q, must be NAME=VALUE", value)
+	}
+	if strings.Contains(parts[1], ",") && strings.Contains(parts[1], "=") {
+		glog.Warningf("DEPRECATED: Use multiple -e flags to specify multiple environment variables instead of comma (%q)", parts[1])
+	}
+	*e = append(*e, EnvironmentSpec{
+		Name:  strings.TrimSpace(parts[0]),
+		Value: strings.TrimSpace(parts[1]),
+	})
+	return nil
+}
+
+// String implements the String() function of pflags.Value interface.
+func (e *EnvironmentList) String() string {
+	result := []string{}
+	for _, i := range *e {
+		result = append(result, strings.Join([]string{i.Name, i.Value}, "="))
+	}
+	return strings.Join(result, ",")
+}
+
+// Type implements the Type() function of pflags.Value interface.
+func (e *EnvironmentList) Type() string {
 	return "string"
 }

--- a/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/pkg/build/strategies/onbuild/onbuild_test.go
@@ -63,7 +63,10 @@ func checkDockerfile(fs *test.FakeFileSystem, t *testing.T) {
 func TestCreateDockerfile(t *testing.T) {
 	fakeRequest := &api.Config{
 		BuilderImage: "fake:onbuild",
-		Environment:  map[string]string{"FOO": "BAR", "TEST": "A VALUE"},
+		Environment: api.EnvironmentList{
+			{Name: "FOO", Value: "BAR"},
+			{Name: "TEST", Value: "A VALUE"},
+		},
 	}
 	b := newFakeOnBuild()
 	fakeFs := &test.FakeFileSystem{

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -603,10 +603,8 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 }
 
 func (b *STI) generateConfigEnv() (configEnv []string) {
-	if len(b.config.Environment) > 0 {
-		for key, val := range b.config.Environment {
-			configEnv = append(configEnv, key+"="+val)
-		}
+	for _, e := range b.config.Environment {
+		configEnv = append(configEnv, strings.Join([]string{e.Name, e.Value}, "="))
 	}
 	return
 }

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -735,14 +735,16 @@ func equalArrayContents(a []string, b []string) bool {
 
 func TestGenerateConfigEnv(t *testing.T) {
 	rh := newFakeSTI(&FakeSTI{})
-	testEnv := map[string]string{
-		"Key1": "Value1",
-		"Key2": "Value2",
-		"Key3": "Value3",
+	testEnv := api.EnvironmentList{
+		{Name: "Key1", Value: "Value1"},
+		{Name: "Key2", Value: "Value2"},
+		{Name: "Key3", Value: "Value3"},
+		{Name: "Key4", Value: "Value=4"},
+		{Name: "Key5", Value: "Value,5"},
 	}
 	rh.config.Environment = testEnv
 	result := rh.generateConfigEnv()
-	expected := []string{"Key1=Value1", "Key2=Value2", "Key3=Value3"}
+	expected := []string{"Key1=Value1", "Key2=Value2", "Key3=Value3", "Key4=Value=4", "Key5=Value,5"}
 	if !equalArrayContents(result, expected) {
 		t.Errorf("Unexpected result. Expected: %#v. Actual: %#v",
 			expected, result)

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/spf13/cobra"
@@ -32,22 +30,4 @@ func AddCommonFlags(c *cobra.Command, cfg *api.Config) {
 		"Specify the path to the Docker configuration file")
 	c.Flags().StringVarP(&(cfg.Destination), "destination", "d", "",
 		"Specify a destination location for untar operation")
-}
-
-// ParseEnvs parses the command line environemnt variable definitions
-func ParseEnvs(c *cobra.Command, name string) (map[string]string, error) {
-	env := c.Flags().Lookup(name)
-	if env == nil || len(env.Value.String()) == 0 {
-		return nil, nil
-	}
-	envs := make(map[string]string)
-	pairs := strings.Split(env.Value.String(), ",")
-	for _, pair := range pairs {
-		atoms := strings.Split(pair, "=")
-		if len(atoms) != 2 {
-			return nil, fmt.Errorf("malformed syntax for environment variable: %s", pair)
-		}
-		envs[atoms[0]] = atoms[1]
-	}
-	return envs, nil
 }


### PR DESCRIPTION
Fixes: https://github.com/openshift/source-to-image/issues/417

@bparees this one is tricky :-) Basically, you can specify a multiple environment variables, by providing multiple `-e FOO=BAR` flags. The syntax we supported before was that you can use something like: `-e FOO=BAR,TEST=FOO`. 

So this is introducing a backward incompatible change. I wonder if we want to make it backward compatible (basically do additional string.Split() in the `Set()` function) or leave it as this (which is consistent with other flags).