### PR TITLE
Replace usage of --force-pull option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $ docker run --rm -i -p :8080 -t test-ruby-app
 ```
 
 ```
-$ s2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-8-centos test-jee-app
+$ s2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 test-jee-app
 $ docker run --rm -i -p :8080 -t test-jee-app
 ```
 

--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -170,7 +170,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.ExcludeRegExp), "exclude", "", tar.DefaultExclusionPattern.String(), "Regular expression for selecting files from the source tree to exclude from the build, where the default excludes the '.git' directory (see https://golang.org/pkg/regexp for syntax, but note that \"\" will be interpreted as allow all files and exclude no files)")
 	buildCmd.Flags().StringVarP(&(cfg.ScriptsURL), "scripts-url", "s", "", "Specify a URL for the assemble and run scripts")
 	buildCmd.Flags().StringVar(&(oldScriptsFlag), "scripts", "", "DEPRECATED: Specify a URL for the assemble and run scripts")
-	buildCmd.Flags().BoolVar(&(useConfig), "use-config", false, "Store command line options to .stifile")
+	buildCmd.Flags().BoolVar(&(useConfig), "use-config", false, "Store command line options to .s2ifile")
 	buildCmd.Flags().StringVarP(&(cfg.EnvironmentFile), "environment-file", "E", "", "Specify the path to the file with environment")
 	buildCmd.Flags().StringVarP(&(cfg.DisplayName), "application-name", "n", "", "Specify the display name for the application (default: output image name)")
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 | `-e (--env)`               | Environment variable to be passed to the builder eg. `NAME=VALUE` |
 | `-E (--environment-file)`  | Specify the path to the file with environment |
 | `--exclude`  | Regular expression for selecting files from the source tree to exclude from the build, where the default excludes the '.git' directory (see https://golang.org/pkg/regexp for syntax, but note that \"\" will be interpreted as allow all files and exclude no files) |
-| `--force-pull`             | Always pull the builder image, even if it is present locally (defaults to true) |
+| `-p (--pull-policy)`       | Specify when to pull the builder image (`always`, `never` or `if-not-present`. Defaults to `if-not-present`) |
 | `--run`                    | Launch the resulting image after a successful build. All output from the image is being printed to help determine image's validity. In case of a long running image you will have to Ctrl-C to exit both s2i and the running container.  (defaults to false) |
 | `-r (--ref)`               | A branch/tag that the build should use instead of MASTER (applies only to Git source) |
 | `--rm`                     | Remove the previous image during incremental builds |
@@ -149,7 +149,7 @@ Build a Node.js application from a local directory, using a local image, the res
 image will be named `nodejs-app`:
 
 ```
-$ s2i build --force-pull=false /home/user/nodejs-app local-nodejs-builder nodejs-app
+$ s2i build /home/user/nodejs-app local-nodejs-builder nodejs-app
 ```
 
 In case of building from the local directory, the sources will be copied into
@@ -159,12 +159,12 @@ Use this method only for development or local testing.
 
 **NOTE**: All your changes have to be commited by `git` in order to build them with S2I.
 
-Build a Java application from a Git source, using the official `wildfly-8-centos`
+Build a Java application from a Git source, using the official `openshift/wildfly-100-centos7`
 builder image but overriding the scripts URL from local directory.  The resulting
 image will be named `java-app`:
 
 ```
-$ s2i build --scripts-url=file://s2iscripts git://github.com/bparees/openshift-jee-sample openshift/wildfly-8-centos java-app
+$ s2i build --scripts-url=file://s2iscripts git://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 java-app
 ```
 
 Build a Ruby application from a Git source, specifying `ref`, and using the official
@@ -218,7 +218,7 @@ $ s2i usage <builder image> [flags]
 |:-------------------------- |:--------------------------------------------------------|
 | `-d (--destination)`       | Location where the scripts and sources will be placed prior invoking usage (see [S2I Scripts](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts))|
 | `-e (--env)`               | Environment variable passed to the builder eg. `NAME=VALUE`) |
-| `--force-pull`             | Always pull the builder image, even if it is present locally |
+| `-p (--pull-policy)`       | Specify when to pull the builder image (`always`, `never` or `if-not-present`) |
 | `--save-temp-dir`          | Save the working directory used for fetching scripts and sources |
 | `-s (--scripts-url)`       | URL of S2I scripts (see [Scripts URL](https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md#s2i-scripts))|
 

--- a/docs/debugging-s2i.md
+++ b/docs/debugging-s2i.md
@@ -19,8 +19,11 @@ As noted [here](https://github.com/openshift/source-to-image/#security), there a
 Image Mechanics
 --------------
 
-By default, s2i will always pull the image from the remote Docker repository rather than using the local builder image if available on the host from which you are running the `s2i` command.  However, if for performance reasons you choose to leverage the `--force-pull=false` option when running the `s2i` command,
-you must guard against the local builder image becoming stale and out of date.
+By default, s2i will use the local builder image if available on the host from
+which you are running the `s2i` command. However, if you want to always pull
+the image from the remote Docker repository to be sure that you are not using
+stale and out of date image you should provide `--pull-policy=always` option
+when running the `s2i` command.
 
 Permissions Needed During the S2I Process
 --------------

--- a/pkg/create/templates/test.go
+++ b/pkg/create/templates/test.go
@@ -29,7 +29,7 @@ cid_file=$($MKTEMP_EXEC -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I to attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false --loglevel=2"
+s2i_args="--pull-policy=never --loglevel=2"
 
 # Port the image exposes service to be tested
 test_port=8080

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -69,7 +69,7 @@ func NewPullImageError(name string, err error) error {
 		Message:    fmt.Sprintf("unable to get %s", name),
 		Details:    err,
 		ErrorCode:  PullImageError,
-		Suggestion: "check image name, or if using local image add --force-pull=false flag",
+		Suggestion: "check image name, or if using local image add --pull-policy=never flag",
 	}
 }
 


### PR DESCRIPTION
Polish documentation a bit:
- use `--pull-policy` instead of `--force-pull` option
- update usage after changing the default value of `--force-pull` from `true` to `false`
- replace usage of deprecated `openshift/wildfly-8-centos` image by `openshift/wildfly-81-centos7`
- replace `.stifile` by `.s2ifile` in `--use-config` option description

PTAL @bparees 