### PR TITLE
Apply several small fixes from go vet and others

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
-// Source-to-image (`sti`) is a tool for building reproducible Docker images. `sti` produces
-// ready-to-run images by injecting source code into a docker image and <i>assembling</i>
-// a new Docker image which incorporates the base image and built source, and is ready to use
-// with `docker run`.
-package sourcetoimage
+// Package s2i is a tool for building reproducible Docker images. The s2i
+// command produces ready-to-run images by injecting source code into a Docker
+// image and assembling a new Docker image which incorporates the base image and
+// built source, and is ready to use with docker run.
+package s2i

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -217,11 +217,13 @@ type EnvironmentSpec struct {
 // EnvironmentList contains list of environment variables.
 type EnvironmentList []EnvironmentSpec
 
+// ProxyConfig holds proxy configuration.
 type ProxyConfig struct {
 	HTTPProxy  *url.URL
 	HTTPSProxy *url.URL
 }
 
+// CGroupLimits holds limits used to constrain container resources.
 type CGroupLimits struct {
 	MemoryLimitBytes int64
 	CPUShares        int64
@@ -230,7 +232,7 @@ type CGroupLimits struct {
 	MemorySwap       int64
 }
 
-// Volume represents a single volume mount point
+// VolumeSpec represents a single volume mount point.
 type VolumeSpec struct {
 	Source      string
 	Destination string

--- a/pkg/build/strategies/layered/layered_test.go
+++ b/pkg/build/strategies/layered/layered_test.go
@@ -152,7 +152,7 @@ func TestBuildErrorCreateTarFile(t *testing.T) {
 	l.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")
 	_, err := l.Build(l.config)
 	if err == nil || err.Error() != "CreateTarError" {
-		t.Error("An error was expected for CreateTar, but got different: %v", err)
+		t.Errorf("An error was expected for CreateTar, but got different: %v", err)
 	}
 }
 
@@ -188,7 +188,7 @@ func TestBuildErrorOnBuildBlocked(t *testing.T) {
 	l.config.BlockOnBuild = true
 	l.config.HasOnBuild = true
 	_, err := l.Build(l.config)
-	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed.") {
+	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed") {
 		t.Errorf("expected error from onbuild due to blocked ONBUILD, got: %v", err)
 	}
 }

--- a/pkg/build/strategies/onbuild/onbuild.go
+++ b/pkg/build/strategies/onbuild/onbuild.go
@@ -51,6 +51,9 @@ func New(config *api.Config, overrides build.Overrides) (*OnBuild, error) {
 	}
 	// Use STI Prepare() and download the 'run' script optionally.
 	s, err := sti.New(config, overrides)
+	if err != nil {
+		return nil, err
+	}
 	s.SetScripts([]string{}, []string{api.Assemble, api.Run})
 
 	downloader := overrides.Downloader
@@ -86,7 +89,7 @@ func (builder *OnBuild) SourceTar(config *api.Config) (io.ReadCloser, error) {
 // Build executes the ONBUILD kind of build
 func (builder *OnBuild) Build(config *api.Config) (*api.Result, error) {
 	if config.BlockOnBuild {
-		return nil, fmt.Errorf("builder image uses ONBUILD instructions but ONBUILD is not allowed.")
+		return nil, fmt.Errorf("builder image uses ONBUILD instructions but ONBUILD is not allowed")
 	}
 	glog.V(2).Info("Preparing the source code for build")
 	// Change the installation directory for this config to store scripts inside
@@ -118,7 +121,7 @@ func (builder *OnBuild) Build(config *api.Config) (*api.Result, error) {
 	}
 
 	glog.V(2).Info("Building the application source")
-	if err := builder.docker.BuildImage(opts); err != nil {
+	if err = builder.docker.BuildImage(opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/pkg/build/strategies/onbuild/onbuild_test.go
@@ -71,9 +71,9 @@ func TestCreateDockerfile(t *testing.T) {
 	b := newFakeOnBuild()
 	fakeFs := &test.FakeFileSystem{
 		Files: []os.FileInfo{
-			&test.FakeFile{"config.ru", false, 0600},
-			&test.FakeFile{"app.rb", false, 0600},
-			&test.FakeFile{"run", false, 0777},
+			&test.FakeFile{FileName: "config.ru", FMode: 0600},
+			&test.FakeFile{FileName: "app.rb", FMode: 0600},
+			&test.FakeFile{FileName: "run", FMode: 0777},
 		},
 	}
 	b.fs = fakeFs
@@ -91,10 +91,10 @@ func TestCreateDockerfileWithAssemble(t *testing.T) {
 	b := newFakeOnBuild()
 	fakeFs := &test.FakeFileSystem{
 		Files: []os.FileInfo{
-			&test.FakeFile{"config.ru", false, 0600},
-			&test.FakeFile{"app.rb", false, 0600},
-			&test.FakeFile{"run", false, 0777},
-			&test.FakeFile{"assemble", false, 0777},
+			&test.FakeFile{FileName: "config.ru", FMode: 0600},
+			&test.FakeFile{FileName: "app.rb", FMode: 0600},
+			&test.FakeFile{FileName: "run", FMode: 0777},
+			&test.FakeFile{FileName: "assemble", FMode: 0777},
 		},
 	}
 	b.fs = fakeFs
@@ -116,9 +116,9 @@ func TestBuild(t *testing.T) {
 	b := newFakeOnBuild()
 	fakeFs := &test.FakeFileSystem{
 		Files: []os.FileInfo{
-			&test.FakeFile{"config.ru", false, 0600},
-			&test.FakeFile{"app.rb", false, 0600},
-			&test.FakeFile{"run", false, 0777},
+			&test.FakeFile{FileName: "config.ru", FMode: 0600},
+			&test.FakeFile{FileName: "app.rb", FMode: 0600},
+			&test.FakeFile{FileName: "run", FMode: 0777},
 		},
 	}
 	b.fs = fakeFs
@@ -142,14 +142,14 @@ func TestBuildOnBuildBlocked(t *testing.T) {
 	b := newFakeOnBuild()
 	fakeFs := &test.FakeFileSystem{
 		Files: []os.FileInfo{
-			&test.FakeFile{"config.ru", false, 0600},
-			&test.FakeFile{"app.rb", false, 0600},
-			&test.FakeFile{"run", false, 0777},
+			&test.FakeFile{FileName: "config.ru", FMode: 0600},
+			&test.FakeFile{FileName: "app.rb", FMode: 0600},
+			&test.FakeFile{FileName: "run", FMode: 0777},
 		},
 	}
 	b.fs = fakeFs
 	_, err := b.Build(fakeRequest)
-	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed.") {
+	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed") {
 		t.Errorf("expected error from onbuild due to blocked ONBUILD, got: %v", err)
 	}
 }

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -183,9 +183,9 @@ func (builder *STI) Build(config *api.Config) (*api.Result, error) {
 	return builder.result, nil
 }
 
-// Prepare prepares the source code and tar for build
-// NOTE, this func serves both the sti and onbuild strategies, as the OnBuild
-// struct Build func leverages the STI struct Prepare func directly below
+// Prepare prepares the source code and tar for build.
+// NOTE: this func serves both the sti and onbuild strategies, as the OnBuild
+// struct Build func leverages the STI struct Prepare func directly below.
 func (builder *STI) Prepare(config *api.Config) error {
 	var err error
 	if len(config.WorkingDir) == 0 {
@@ -201,7 +201,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 
 	// Setup working directories
 	for _, v := range workingDirs {
-		if err := builder.fs.MkdirAll(filepath.Join(config.WorkingDir, v)); err != nil {
+		if err = builder.fs.MkdirAll(filepath.Join(config.WorkingDir, v)); err != nil {
 			return err
 		}
 	}

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -72,7 +72,7 @@ func newFakeSTI(f *FakeSTI) *STI {
 		garbage:   f,
 		layered:   &FakeDockerBuild{f},
 	}
-	s.source = &git.Clone{s.git, s.fs}
+	s.source = &git.Clone{Git: s.git, FileSystem: s.fs}
 	return s
 }
 
@@ -304,7 +304,7 @@ func testBuildHandler() *STI {
 		result:            &api.Result{},
 		callbackInvoker:   &test.FakeCallbackInvoker{},
 	}
-	s.source = &git.Clone{s.git, s.fs}
+	s.source = &git.Clone{Git: s.git, FileSystem: s.fs}
 	return s
 }
 
@@ -551,7 +551,7 @@ func TestFetchSource(t *testing.T) {
 		cloneExpected    bool
 		checkoutExpected bool
 		copyExpected     bool
-		source_path      string
+		sourcePath       string
 		expectedError    *error
 	}
 
@@ -564,7 +564,7 @@ func TestFetchSource(t *testing.T) {
 			cloneExpected:    false,
 			checkoutExpected: false,
 			copyExpected:     false,
-			source_path:      "invalid/path",
+			sourcePath:       "invalid/path",
 			expectedError:    &err,
 		},
 		// 1
@@ -603,10 +603,10 @@ func TestFetchSource(t *testing.T) {
 		if ft.refSpecified {
 			bh.config.Ref = "a-branch"
 		}
-		if len(ft.source_path) == 0 {
+		if len(ft.sourcePath) == 0 {
 			bh.config.Source = "a-repo-source"
 		} else {
-			bh.config.Source = ft.source_path
+			bh.config.Source = ft.sourcePath
 		}
 
 		expectedTargetDir := "/working-dir/upload/src"
@@ -620,7 +620,7 @@ func TestFetchSource(t *testing.T) {
 				continue
 			}
 			if (*ft.expectedError).(stierr.Error).ErrorCode != e.(stierr.Error).ErrorCode {
-				t.Errorf("Expected error code %s, got %s [%d]", (*ft.expectedError).(stierr.Error).ErrorCode, e.(stierr.Error).ErrorCode, testNum)
+				t.Errorf("Expected error code %d, got %d [%d]", (*ft.expectedError).(stierr.Error).ErrorCode, e.(stierr.Error).ErrorCode, testNum)
 			}
 		}
 		if ft.cloneExpected {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -22,11 +22,12 @@ import (
 )
 
 const (
-	// Deprecated environment variable name, specifying where to look for the S2I scripts.
-	// It is now being replaced with ScriptsURLLabel.
+	// ScriptsURLEnvironment is a deprecated environment variable name that
+	// specifies where to look for S2I scripts. Use ScriptsURLLabel instead.
 	ScriptsURLEnvironment = "STI_SCRIPTS_URL"
-	// Deprecated environment variable name, specifying where to place artifacts in
-	// builder image. It is now being replaced with DestinationLabel.
+	// LocationEnvironment is a deprecated environment variable name that
+	// specifies where to place artifacts in a builder image. Use
+	// DestinationLabel instead.
 	LocationEnvironment = "STI_LOCATION"
 
 	// ScriptsURLLabel is the name of the Docker image LABEL that tells S2I where
@@ -607,7 +608,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 	// Create a new container.
 	glog.V(2).Infof("Creating container with options {Name:%q Config:%+v HostConfig:%+v} ...", createOpts.Name, createOpts.Config, createOpts.HostConfig)
 	var container *docker.Container
-	if err := util.TimeoutAfter(DefaultDockerTimeout, "timeout after waiting %v for Docker to create container", func() error {
+	if err = util.TimeoutAfter(DefaultDockerTimeout, "timeout after waiting %v for Docker to create container", func() error {
 		var createErr error
 		container, createErr = d.client.CreateContainer(createOpts)
 		return createErr
@@ -692,7 +693,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 
 		// OnStart must be done before we move on.
 		if opts.OnStart != nil {
-			if err := <-onStartDone; err != nil {
+			if err = <-onStartDone; err != nil {
 				return err
 			}
 		}

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -16,8 +16,8 @@ import (
 	"github.com/openshift/source-to-image/pkg/util/user"
 )
 
-// DockerImageReference points to a Docker image.
-type DockerImageReference struct {
+// ImageReference points to a Docker image.
+type ImageReference struct {
 	Registry  string
 	Namespace string
 	Name      string
@@ -35,7 +35,7 @@ const (
 // image name and a given set of client authentication objects.
 func GetImageRegistryAuth(auths *client.AuthConfigurations, imageName string) client.AuthConfiguration {
 	glog.V(5).Infof("Getting docker credentials for %s", imageName)
-	spec, err := ParseDockerImageReference(imageName)
+	spec, err := ParseImageReference(imageName)
 	if err != nil {
 		glog.Errorf("Failed to parse docker reference %s", imageName)
 		return client.AuthConfiguration{}
@@ -95,13 +95,11 @@ func StreamContainerIO(errStream io.Reader, errOutput *string, log func(...inter
 	}
 }
 
-// ParseDockerImageReference parses a Docker pull spec string into a
-// DockerImageReference.
-// FIXME: This code was copied from OpenShift repository
-func ParseDockerImageReference(spec string) (DockerImageReference, error) {
-	var (
-		ref DockerImageReference
-	)
+// ParseImageReference parses a Docker pull spec string into a ImageReference.
+// FIXME: This code was copied from OpenShift repository.
+func ParseImageReference(spec string) (ImageReference, error) {
+	var ref ImageReference
+
 	// TODO replace with docker version once docker/docker PR11109 is merged upstream
 	stream, tag, id := parseRepositoryTag(spec)
 

--- a/pkg/scm/git/clone.go
+++ b/pkg/scm/git/clone.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/util"
 )
 
+// Clone knows how to clone a Git repository.
 type Clone struct {
 	Git
 	util.FileSystem

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -41,14 +41,14 @@ func DownloaderForSource(s string, forceCopy bool) (build.Downloader, string, er
 	}
 
 	if details.FileExists && (details.UseCopy || forceCopy) {
-		return &file.File{util.NewFileSystem()}, s, nil
+		return &file.File{FileSystem: util.NewFileSystem()}, s, nil
 	}
 
 	// If the source is valid  Git protocol (file://, ssh://, git://, git@, etc..) use Git
 	// binary to download the sources
 	g := git.New()
 	if g.ValidCloneSpec(s) {
-		return &git.Clone{g, util.NewFileSystem()}, s, nil
+		return &git.Clone{Git: g, FileSystem: util.NewFileSystem()}, s, nil
 	}
 
 	return nil, s, fmt.Errorf("no downloader defined for location: %q", s)

--- a/pkg/scripts/download_test.go
+++ b/pkg/scripts/download_test.go
@@ -30,8 +30,8 @@ func (f *FakeHTTPGet) get(url string) (*http.Response, error) {
 	}, f.err
 }
 
-func getHTTPReader() (*HttpURLReader, *FakeHTTPGet) {
-	sr := &HttpURLReader{}
+func getHTTPReader() (*HTTPURLReader, *FakeHTTPGet) {
+	sr := &HTTPURLReader{}
 	g := &FakeHTTPGet{content: "test content", statusCode: 200}
 	sr.Get = g.get
 	return sr, g

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -108,7 +108,7 @@ func (t *stiTar) StreamDirAsTar(source, dest string, writer io.Writer) error {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
-	if err := fs.Copy(source, tmpDir); err != nil {
+	if err = fs.Copy(source, tmpDir); err != nil {
 		return err
 	}
 	// Skip chmod if on windows OS
@@ -198,7 +198,7 @@ func (t *stiTar) CreateTarStreamWithLogging(dir string, includeDirInPath bool, w
 		if !info.IsDir() && !t.shouldExclude(path) {
 			// if file is a link just writing header info is enough
 			if info.Mode()&os.ModeSymlink != 0 {
-				if err := t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
+				if err = t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
 					glog.Errorf("Error writing header for %q: %v", info.Name(), err)
 				}
 				return err
@@ -211,7 +211,7 @@ func (t *stiTar) CreateTarStreamWithLogging(dir string, includeDirInPath bool, w
 				return nil
 			}
 			defer file.Close()
-			if err := t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
+			if err = t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
 				glog.Errorf("Error writing header for %q: %v", info.Name(), err)
 				return err
 			}

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -137,7 +137,7 @@ func TestCreateTarStreamIncludeParentDir(t *testing.T) {
 		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
 		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
 	}
-	if err := createTestFiles(tempDir, testFiles); err != nil {
+	if err = createTestFiles(tempDir, testFiles); err != nil {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	th := New()
@@ -172,7 +172,7 @@ func TestCreateTar(t *testing.T) {
 		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
 		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
 	}
-	if err := createTestFiles(tempDir, testFiles); err != nil {
+	if err = createTestFiles(tempDir, testFiles); err != nil {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	testLinks := []linkDesc{
@@ -181,7 +181,7 @@ func TestCreateTar(t *testing.T) {
 		{"link/okdirlink", "../dir01/dir02"},
 		{"link/errdirlink", "../dir01/.git"},
 	}
-	if err := createTestLinks(tempDir, testLinks); err != nil {
+	if err = createTestLinks(tempDir, testLinks); err != nil {
 		t.Fatalf("Cannot create link files: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestCreateTarIncludeDotGit(t *testing.T) {
 		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", true, ""},
 		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
 	}
-	if err := createTestFiles(tempDir, testFiles); err != nil {
+	if err = createTestFiles(tempDir, testFiles); err != nil {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	testLinks := []linkDesc{
@@ -217,7 +217,7 @@ func TestCreateTarIncludeDotGit(t *testing.T) {
 		{"link/okdirlink", "../dir01/dir02"},
 		{"link/okdirlink2", "../dir01/.git"},
 	}
-	if err := createTestLinks(tempDir, testLinks); err != nil {
+	if err = createTestLinks(tempDir, testLinks); err != nil {
 		t.Fatalf("Cannot create link files: %v", err)
 	}
 
@@ -244,7 +244,7 @@ func TestCreateTarEmptyRegexp(t *testing.T) {
 		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
 		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
 	}
-	if err := createTestFiles(tempDir, testFiles); err != nil {
+	if err = createTestFiles(tempDir, testFiles); err != nil {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	testLinks := []linkDesc{
@@ -253,7 +253,7 @@ func TestCreateTarEmptyRegexp(t *testing.T) {
 		{"link/okdirlink", "../dir01/dir02"},
 		{"link/okdirlink2", "../dir01/.git"},
 	}
-	if err := createTestLinks(tempDir, testLinks); err != nil {
+	if err = createTestLinks(tempDir, testLinks); err != nil {
 		t.Fatalf("Cannot create link files: %v", err)
 	}
 

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -129,7 +129,7 @@ func (h *fs) CopyContents(src string, dest string) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dest, sourceinfo.Mode()); err != nil {
+	if err = os.MkdirAll(dest, sourceinfo.Mode()); err != nil {
 		return err
 	}
 	directory, err := os.Open(src)

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -1,3 +1,2 @@
-// Package version supplies version information for STI collected at build time
-
+// Package version supplies version information for STI collected at build time.
 package version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,8 +21,8 @@ type Info struct {
 	GitVersion string `json:"gitVersion"`
 }
 
-// Get returns the overall codebase version. It's for detecting
-// what code a binary was built from.
+// Get returns the overall codebase version. It's for detecting what code a
+// binary was built from.
 func Get() Info {
 	return Info{
 		Major:      majorFromGit,

--- a/test/integration/doc.go
+++ b/test/integration/doc.go
@@ -1,3 +1,2 @@
-// Package integration contains integration tests for STI
-
+// Package integration contains integration tests for S2I.
 package integration


### PR DESCRIPTION
Includes:
- Changes to commentaries to follow godoc conventions;
- Fix shadowing of identifiers;
- Missing error checks;
- Fix incorrect usages of fmt.Print* functions;
- Initialize struct literals from other packages using explicit field
  names;
- Rename variables (not used in origin) to follow Go conventions.