### PR TITLE
Fix ldflag logic

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -436,8 +436,7 @@ sti::build::ldflag() {
   local val=${2}
 
   GO_VERSION=($(go version))
-
-  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.5') ]]; then
+  if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
     echo "-X ${STI_GO_PACKAGE}/pkg/version.${key} ${val}"
   else
     echo "-X ${STI_GO_PACKAGE}/pkg/version.${key}=${val}"


### PR DESCRIPTION
The condition should test for `go1.4` and use `${key} ${val}`, while `go1.5` and `go1.6` should use `${key}=${val}`.

The actual test could consider versions prior to go1.4, but I think we don't care about them, i.e., we require go1.4+?