### PR TITLE
Replace 'sti::' with 's2i::' in Bash scripts

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -10,15 +10,15 @@ STARTTIME=$(date +%s)
 STI_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${STI_ROOT}/hack/common.sh"
 source "${STI_ROOT}/hack/util.sh"
-sti::log::install_errexit
+s2i::log::install_errexit
 
 # Build the primary for all platforms
 STI_BUILD_PLATFORMS=("${STI_CROSS_COMPILE_PLATFORMS[@]}")
-sti::build::build_binaries "${STI_CROSS_COMPILE_TARGETS[@]}"
+s2i::build::build_binaries "${STI_CROSS_COMPILE_TARGETS[@]}"
 
 # Make the primary release.
 STI_RELEASE_ARCHIVE="source-to-image"
 STI_BUILD_PLATFORMS=("${STI_CROSS_COMPILE_PLATFORMS[@]}")
-sti::build::place_bins "${STI_CROSS_COMPILE_BINARIES[@]}"
+s2i::build::place_bins "${STI_CROSS_COMPILE_BINARIES[@]}"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -9,6 +9,6 @@ set -o pipefail
 STI_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${STI_ROOT}/hack/common.sh"
 
-sti::build::build_binaries "$@"
-sti::build::place_bins
-sti::build::make_binary_symlinks
+s2i::build::build_binaries "$@"
+s2i::build::place_bins
+s2i::build::make_binary_symlinks

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -11,7 +11,7 @@ STARTTIME=$(date +%s)
 STI_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${STI_ROOT}/hack/common.sh"
 source "${STI_ROOT}/hack/util.sh"
-sti::log::install_errexit
+s2i::log::install_errexit
 
 # Go to the top of the tree.
 cd "${STI_ROOT}"
@@ -30,8 +30,8 @@ mkdir -p "${STI_OUTPUT}"
 
 # Generate version definitions.
 # You can commit a specific version by specifying STI_GIT_COMMIT="" prior to build
-sti::build::get_version_vars
-sti::build::save_version_vars "${context}/sti-version-defs"
+s2i::build::get_version_vars
+s2i::build::save_version_vars "${context}/sti-version-defs"
 
 echo "++ Building release ${STI_GIT_VERSION}"
 

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -15,9 +15,9 @@ cd "${STI_ROOT}"
 
 # Copy the linux release archives release back to the local _output/local/bin/linux/amd64 directory.
 # TODO: support different OS's?
-sti::build::detect_local_release_tars "linux-amd64"
+s2i::build::detect_local_release_tars "linux-amd64"
 
 mkdir -p "${STI_OUTPUT_BINPATH}/linux/amd64"
 tar mxzf "${STI_PRIMARY_RELEASE_TAR}" -C "${STI_OUTPUT_BINPATH}/linux/amd64"
 
-sti::build::make_binary_symlinks
+s2i::build::make_binary_symlinks

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -10,7 +10,7 @@ source "${STI_ROOT}/hack/common.sh"
 # Go to the top of the tree.
 cd "${STI_ROOT}"
 
-sti::build::setup_env
+s2i::build::setup_env
 
 find_test_dirs() {
   cd "${STI_ROOT}"

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -8,7 +8,7 @@ STI_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${STI_ROOT}/hack/common.sh"
 
-sti::build::build_binaries "$@"
+s2i::build::build_binaries "$@"
 
 echo "+++ Updating Bash completion in contrib/bash/s2i"
 ${STI_LOCAL_BINPATH}/s2i genbashcompletion > ${STI_ROOT}/contrib/bash/s2i

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -4,7 +4,7 @@
 
 # Handler for when we exit automatically on an error.
 # Borrowed from https://gist.github.com/ahendrix/7030300
-sti::log::errexit() {
+s2i::log::errexit() {
   local err="${PIPESTATUS[@]}"
 
   # If the shell we are in doesn't have errexit set (common in subshells) then
@@ -13,13 +13,13 @@ sti::log::errexit() {
 
   set +o xtrace
   local code="${1:-1}"
-  sti::log::error_exit "'${BASH_COMMAND}' exited with status $err" "${1:-1}" 1
+  s2i::log::error_exit "'${BASH_COMMAND}' exited with status $err" "${1:-1}" 1
 }
 
-sti::log::install_errexit() {
+s2i::log::install_errexit() {
   # trap ERR to provide an error handler whenever a command exits nonzero this
   # is a more verbose version of set -o errexit
-  trap 'sti::log::errexit' ERR
+  trap 's2i::log::errexit' ERR
 
   # setting errtrace allows our ERR trap handler to be propagated to functions,
   # expansions and subshells
@@ -30,7 +30,7 @@ sti::log::install_errexit() {
 #
 # Args:
 #  $1 The number of stack frames to skip when printing.
-sti::log::stack() {
+s2i::log::stack() {
   local stack_skip=${1:-0}
   stack_skip=$((stack_skip + 1))
   if [[ ${#FUNCNAME[@]} -gt $stack_skip ]]; then
@@ -52,7 +52,7 @@ sti::log::stack() {
 #  $1 Message to log with the error
 #  $2 The error code to return
 #  $3 The number of stack frames to skip when printing.
-sti::log::error_exit() {
+s2i::log::error_exit() {
   local message="${1:-}"
   local code="${2:-1}"
   local stack_skip="${3:-0}"
@@ -65,7 +65,7 @@ sti::log::error_exit() {
   echo "  ${1}" >&2
   }
 
-  sti::log::stack $stack_skip
+  s2i::log::stack $stack_skip
 
   echo "Exiting with status ${code}" >&2
   exit "${code}"


### PR DESCRIPTION
Gradually getting rid of 'sti'.