### PR TITLE
Fix hack/verify-*.sh and improve other scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - make install-travis
 
 script:
+  - make verify
   - make check TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5.3
-  - 1.6
+  - 1.5.4
+  - 1.6.2
 
 install:
   - make install-travis

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ all build:
 #   make verify
 verify: build
 	hack/verify-gofmt.sh
-	hack/verify-golint.sh || true
-	hack/verify-govet.sh || true
+	hack/verify-golint.sh || true # ignored until existing lint errors are gone
+	hack/verify-govet.sh
 .PHONY: verify
 
 # Install travis dependencies

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
-S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${S2I_ROOT}/hack/common.sh"
+STARTTIME=$(date +%s)
 
-GO_VERSION=($(go version))
-echo "Detected go version: $(go version)"
+echo $(go version)
 
-go get golang.org/x/tools/cmd/cover github.com/tools/godep
+go get github.com/tools/godep github.com/golang/lint/golint
+
+ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/rebase-to-origin.sh
+++ b/hack/rebase-to-origin.sh
@@ -48,7 +48,7 @@ pushd "${OS_ROOT}" >/dev/null
   done
 
   # Bump the origin Godeps.json file
-  os::util::sed "s/${s2i_godeps_ref}/${s2i_ref}/g" "${OS_ROOT}/Godeps/Godeps.json"
+  s2i::util::sed "s/${s2i_godeps_ref}/${s2i_ref}/g" "${OS_ROOT}/Godeps/Godeps.json"
 
   # Make a commit with proper message
   git add Godeps && git commit -m "bump(github.com/openshift/source-to-image): ${s2i_ref}"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -71,7 +71,7 @@ s2i::log::error_exit() {
   exit "${code}"
 }
 
-os::util::sed() {
+s2i::util::sed() {
   if [[ "$(go env GOHOSTOS)" == "darwin" ]]; then
     sed -i '' $@
   else
@@ -79,13 +79,6 @@ os::util::sed() {
   fi
 }
 
-find_files() {
-  find . -not \( \
-      \( \
-        -wholename './_output' \
-        -o -wholename './_tools' \
-        -o -wholename './.*' \
-        -o -wholename '*/Godeps/*' \
-      \) -prune \
-    \) -name '*.go' | sort -u
+s2i::util::find_files() {
+  find . -type d -name Godeps -prune -o -name '*.go' -print
 }

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -4,34 +4,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
-  echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
-  exit 0
-fi
+echo $(go version)
 
 S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${S2I_ROOT}/hack/common.sh"
+source "${S2I_ROOT}/hack/util.sh"
 
 cd "${S2I_ROOT}"
 
-find_files() {
-  find . -not \( \
-      \( \
-        -wholename './output' \
-        -o -wholename './_output' \
-        -o -wholename './release' \
-        -o -wholename './target' \
-        -o -wholename '*/Godeps/*' \
-      \) -prune \
-    \) -name '*.go'
-}
-
-bad_files=$(find_files | xargs gofmt -s -l)
+bad_files=$(s2i::util::find_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then
-  echo "!!! gofmt needs to be run on the following files: "
+  echo "!!! gofmt needs to be run on the following files: " >&2
   echo "${bad_files}"
-  echo "Try running 'gofmt -s -d [path]'"
+  echo "Try running 'gofmt -s -d [path]'" >&2
+  echo "Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'" >&2
   exit 1
 fi

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 set -o errexit
+set -o nounset
 set -o pipefail
+
+echo $(go version)
 
 if ! which golint &>/dev/null; then
   echo "Unable to detect 'golint' package"
@@ -9,46 +12,15 @@ if ! which golint &>/dev/null; then
   exit 1
 fi
 
-GO_VERSION=($(go version))
-echo "Detected go version: $(go version)"
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping golint."
-  exit 0
-fi
-
 S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${S2I_ROOT}/hack/common.sh"
+source "${S2I_ROOT}/hack/util.sh"
 
 cd "${S2I_ROOT}"
 
-arg="${1:-""}"
-bad_files=""
-
-if [ "$arg" == "-m" ]; then
-  head=$(git rev-parse --short HEAD | xargs echo -n)
-  bad_files=$(git diff-tree --no-commit-id --name-only -r master..$head | \
-    grep "^pkg" | grep ".go$" | grep -v "bindata.go$" | grep -v "Godeps" | \
-    grep -v "third_party" | xargs golint)
-else
-  find_files() {
-    find . -not \( \
-      \( \
-        -wholename './Godeps' \
-        -o -wholename './release' \
-        -o -wholename './target' \
-        -o -wholename './test' \
-        -o -wholename '*/Godeps/*' \
-        -o -wholename '*/third_party/*' \
-        -o -wholename '*/_output/*' \
-      \) -prune \
-    \) -name '*.go' | sort -u | sed 's/^.{2}//' | xargs -n1 printf "${GOPATH}/src/${S2I_GO_PACKAGE}/%s\n"
-  }
-  bad_files=$(find_files | xargs -n1 golint)
-fi
+bad_files=$(s2i::util::find_files | xargs -n1 golint)
 
 if [[ -n "${bad_files}" ]]; then
-  echo "golint detected following problems:"
+  echo "!!! golint detected the following problems:"
   echo "${bad_files}"
   exit 1
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,28 +1,21 @@
 #!/bin/bash
 
+set -o errexit
 set -o nounset
 set -o pipefail
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.[5-6]') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping go vet."
-  exit 0
-fi
+echo $(go version)
 
 S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${S2I_ROOT}/hack/common.sh"
 source "${S2I_ROOT}/hack/util.sh"
 
 cd "${S2I_ROOT}"
-mkdir -p _output/govet
 
 FAILURE=false
-test_dirs=$(find_files | cut -d '/' -f 1-2 | sort -u)
+test_dirs=$(s2i::util::find_files | cut -d '/' -f 1-2 | sort -u)
 for test_dir in $test_dirs
 do
-  go vet -shadow=false $test_dir
-  if [ "$?" -ne 0 ]
+  if ! go tool vet -shadow=false -composites=false $test_dir
   then
     FAILURE=true
   fi


### PR DESCRIPTION
Summary:
- Add 'make verify' to Travis.
- Fix verify-golint.sh: old invocation would not work unless GOPATH is a
  single directory.
- Fix verify-govet.go: 'go vet' does not take flags, should use 'go tool
  vet'.
- Fix early termination of hack/verify-govet.sh.
- Enable 'go vet' in 'make verify'; will prevent introducing problems
  detected by the vet tool in future PRs.
- Make sure golint is installed in Travis.
- Improve install-tools.sh, parity with the one in openshift/origin.
- s/os::util::sed/s2i::util::sed for consistency.
- Reimplement/simplify find_files, now called s2i::util::find_files, and
  use it in all scripts consistently.
- Suggest autocorrection for gofmt, as seen in openshift/origin.
- Do not check Go version (verify-*.sh should be run no matter the Go
  version?!).
- Do not create directory _output/govet (not used?!).

Also:
- Bump minor versions of Go 1.5 and 1.6.