### PR TITLE
Name containers created by s2i explicitly

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -355,6 +357,7 @@ func checkErr(err error) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	cfg := &api.Config{}
 	stiCmd := &cobra.Command{
 		Use: "s2i",

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"reflect"
 	"testing"
@@ -12,6 +13,15 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 )
+
+func TestContainerName(t *testing.T) {
+	rand.Seed(0)
+	got := containerName("sub.domain.com:5000/repo:tag@sha256:ffffff")
+	want := "s2i_sub_domain_com_5000_repo_tag_sha256_ffffff_f1f85ff5"
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
 
 func getDocker(client Client) *stiDocker {
 	return &stiDocker{


### PR DESCRIPTION
Instead of leaving the name blank and letting the Docker daemon name
containers with random strings like 'lonely_thompson', we give proper
names so that we can identify and filter containers created by S2I
later.

Names take a fixed prefix, 's2i_', and a random suffix. The builder
image is also used to compose the container name, replacing with
underscores characters that would be invalid for a container name.

Example:

```console
$ s2i build \
    git://github.com/openshift/ruby-hello-world \
    centos/ruby-22-centos7 \
    hello-world-app
```

The above creates a temporary container named
's2i_centos_ruby_22_centos7_397cfecd'.

-----------------------------------------

Fixes #395.