### PR TITLE
Replace STI_* env vars with S2I_*

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,11 @@ To run all tests with verbose output:
 
 To turn off or change the coverage mode, which is `-cover -covermode=atomic` by default, use:
 
-    $ STI_COVER="" hack/test-go.sh
+    $ S2I_COVER="" hack/test-go.sh
 
 To run tests without the go race detector, which is on by default, use:
 
-    $ STI_RACE="" hack/test-go.sh
+    $ S2I_RACE="" hack/test-go.sh
 
 A line coverage report is run by default when testing a single package.
 To create a coverage report for all packages:

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -2,18 +2,18 @@
 
 # This script builds release images for use by the release build.
 #
-# Set STI_IMAGE_PUSH=true to push images to a registry
+# Set S2I_IMAGE_PUSH=true to push images to a registry
 #
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
 # Go to the top of the tree.
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 # Build the images
-docker build --tag openshift/sti-release "${STI_ROOT}/images/release"
+docker build --tag openshift/sti-release "${S2I_ROOT}/images/release"

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -7,18 +7,18 @@ set -o nounset
 set -o pipefail
 
 STARTTIME=$(date +%s)
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
-source "${STI_ROOT}/hack/util.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
+source "${S2I_ROOT}/hack/util.sh"
 s2i::log::install_errexit
 
 # Build the primary for all platforms
-STI_BUILD_PLATFORMS=("${STI_CROSS_COMPILE_PLATFORMS[@]}")
-s2i::build::build_binaries "${STI_CROSS_COMPILE_TARGETS[@]}"
+S2I_BUILD_PLATFORMS=("${S2I_CROSS_COMPILE_PLATFORMS[@]}")
+s2i::build::build_binaries "${S2I_CROSS_COMPILE_TARGETS[@]}"
 
 # Make the primary release.
-STI_RELEASE_ARCHIVE="source-to-image"
-STI_BUILD_PLATFORMS=("${STI_CROSS_COMPILE_PLATFORMS[@]}")
-s2i::build::place_bins "${STI_CROSS_COMPILE_BINARIES[@]}"
+S2I_RELEASE_ARCHIVE="source-to-image"
+S2I_BUILD_PLATFORMS=("${S2I_CROSS_COMPILE_PLATFORMS[@]}")
+s2i::build::place_bins "${S2I_CROSS_COMPILE_BINARIES[@]}"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -6,8 +6,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
 s2i::build::build_binaries "$@"
 s2i::build::place_bins

--- a/hack/build-test-images.sh
+++ b/hack/build-test-images.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly STI_ROOT=$(dirname "${BASH_SOURCE}")/..
+readonly S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 s2i::build_test_image() {
   local image_name="$1"
@@ -19,7 +19,7 @@ s2i::build_test_image() {
 
 (
   # Go to the top of the tree.
-  cd "${STI_ROOT}"
+  cd "${S2I_ROOT}"
 
   s2i::build_test_image sti-fake
   s2i::build_test_image sti-fake-env

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -7,17 +7,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
 # Go to the top of the tree.
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 # Copy the linux release archives release back to the local _output/local/bin/linux/amd64 directory.
 # TODO: support different OS's?
 s2i::build::detect_local_release_tars "linux-amd64"
 
-mkdir -p "${STI_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${STI_PRIMARY_RELEASE_TAR}" -C "${STI_OUTPUT_BINPATH}/linux/amd64"
+mkdir -p "${S2I_OUTPUT_BINPATH}/linux/amd64"
+tar mxzf "${S2I_PRIMARY_RELEASE_TAR}" -C "${S2I_OUTPUT_BINPATH}/linux/amd64"
 
 s2i::build::make_binary_symlinks

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
 GO_VERSION=($(go version))
 echo "Detected go version: $(go version)"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -4,16 +4,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
 # Go to the top of the tree.
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 s2i::build::setup_env
 
 find_test_dirs() {
-  cd "${STI_ROOT}"
+  cd "${S2I_ROOT}"
   find . -not \( \
       \( \
         -wholename './Godeps' \
@@ -23,53 +23,53 @@ find_test_dirs() {
         -o -wholename '*/_output/*' \
         -o -wholename './.git' \
       \) -prune \
-    \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${STI_GO_PACKAGE}/%s\n"
+    \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${S2I_GO_PACKAGE}/%s\n"
 }
 
 # -covermode=atomic becomes default with -race in Go >=1.3
-if [ -z ${STI_COVER+x} ]; then
-  STI_COVER=""
+if [ -z ${S2I_COVER+x} ]; then
+  S2I_COVER=""
 fi
 
 OUTPUT_COVERAGE=${OUTPUT_COVERAGE:-""}
 
 if [ -n "${OUTPUT_COVERAGE}" ]; then
-  if [ -z ${STI_RACE+x} ]; then
-    STI_RACE="-race"
+  if [ -z ${S2I_RACE+x} ]; then
+    S2I_RACE="-race"
   fi
-  if [ -z "${STI_COVER}" ]; then
-    STI_COVER="-cover -covermode=atomic"
+  if [ -z "${S2I_COVER}" ]; then
+    S2I_COVER="-cover -covermode=atomic"
   fi
 fi
 
-if [ -z ${STI_RACE+x} ]; then
-  STI_RACE=""
+if [ -z ${S2I_RACE+x} ]; then
+  S2I_RACE=""
 fi
 
-STI_TIMEOUT=${STI_TIMEOUT:--timeout 60s}
+S2I_TIMEOUT=${S2I_TIMEOUT:--timeout 60s}
 
 if [ "${1-}" != "" ]; then
-  test_packages="$STI_GO_PACKAGE/$1"
+  test_packages="$S2I_GO_PACKAGE/$1"
 else
   test_packages=`find_test_dirs`
 fi
 
-if [[ -n "${STI_COVER}" && -n "${OUTPUT_COVERAGE}" ]]; then
+if [[ -n "${S2I_COVER}" && -n "${OUTPUT_COVERAGE}" ]]; then
   # Iterate over packages to run coverage
   test_packages=( $test_packages )
   for test_package in "${test_packages[@]}"
   do
     mkdir -p "$OUTPUT_COVERAGE/$test_package"
-    STI_COVER_PROFILE="-coverprofile=$OUTPUT_COVERAGE/$test_package/profile.out"
+    S2I_COVER_PROFILE="-coverprofile=$OUTPUT_COVERAGE/$test_package/profile.out"
 
-    go test $STI_RACE $STI_TIMEOUT $STI_COVER "$STI_COVER_PROFILE" "$test_package" "${@:2}"
+    go test $S2I_RACE $S2I_TIMEOUT $S2I_COVER "$S2I_COVER_PROFILE" "$test_package" "${@:2}"
   done
 
   echo 'mode: atomic' > ${OUTPUT_COVERAGE}/profiles.out
   find $OUTPUT_COVERAGE -name profile.out | xargs sed '/^mode: atomic$/d' >> ${OUTPUT_COVERAGE}/profiles.out
   go tool cover "-html=${OUTPUT_COVERAGE}/profiles.out" -o "${OUTPUT_COVERAGE}/coverage.html"
 
-  rm -rf $OUTPUT_COVERAGE/$STI_GO_PACKAGE
+  rm -rf $OUTPUT_COVERAGE/$S2I_GO_PACKAGE
 else
-  go test $STI_RACE $STI_TIMEOUT $STI_COVER "${@:2}" $test_packages
+  go test $S2I_RACE $S2I_TIMEOUT $S2I_COVER "${@:2}" $test_packages
 fi

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly STI_ROOT=$(dirname "${BASH_SOURCE}")/..
+readonly S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 s2i::cleanup() {
   echo
@@ -24,4 +24,4 @@ echo
 echo "Running integration tests ..."
 echo
 
-STI_TIMEOUT="-timeout 600s" "${STI_ROOT}/hack/test-go.sh" test/integration -v -tags 'integration' "${@:1}"
+S2I_TIMEOUT="-timeout 600s" "${S2I_ROOT}/hack/test-go.sh" test/integration -v -tags 'integration' "${@:1}"

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -4,11 +4,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-source "${STI_ROOT}/hack/common.sh"
+source "${S2I_ROOT}/hack/common.sh"
 
 s2i::build::build_binaries "$@"
 
 echo "+++ Updating Bash completion in contrib/bash/s2i"
-${STI_LOCAL_BINPATH}/s2i genbashcompletion > ${STI_ROOT}/contrib/bash/s2i
+${S2I_LOCAL_BINPATH}/s2i genbashcompletion > ${S2I_ROOT}/contrib/bash/s2i

--- a/hack/verify-bash-completion.sh
+++ b/hack/verify-bash-completion.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 mv contrib/bash/s2i contrib/bash/s2i-proposed
 hack/update-generated-completions.sh

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -11,10 +11,10 @@ if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
   exit 0
 fi
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 find_files() {
   find . -not \( \

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -17,10 +17,10 @@ if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
   exit 0
 fi
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
 
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 
 arg="${1:-""}"
 bad_files=""
@@ -42,7 +42,7 @@ else
         -o -wholename '*/third_party/*' \
         -o -wholename '*/_output/*' \
       \) -prune \
-    \) -name '*.go' | sort -u | sed 's/^.{2}//' | xargs -n1 printf "${GOPATH}/src/${STI_GO_PACKAGE}/%s\n"
+    \) -name '*.go' | sort -u | sed 's/^.{2}//' | xargs -n1 printf "${GOPATH}/src/${S2I_GO_PACKAGE}/%s\n"
   }
   bad_files=$(find_files | xargs -n1 golint)
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -10,11 +10,11 @@ if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.[5-6]') ]]; then
   exit 0
 fi
 
-STI_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${STI_ROOT}/hack/common.sh"
-source "${STI_ROOT}/hack/util.sh"
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
+source "${S2I_ROOT}/hack/util.sh"
 
-cd "${STI_ROOT}"
+cd "${S2I_ROOT}"
 mkdir -p _output/govet
 
 FAILURE=false

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/openshift/source-to-image
 ENV GOARM 5
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 
-ENV STI_VERSION_FILE /go/src/github.com/openshift/source-to-image/sti-version-defs
+ENV S2I_VERSION_FILE /go/src/github.com/openshift/source-to-image/sti-version-defs
 
 # Expect a tar with the source of STI (and /sti-version-defs in the root)
 CMD tar mxzf - && hack/build-cross.sh


### PR DESCRIPTION
This is a careful replacement of `STI_([A-Z_]+)` with `S2I_$1` in all
*.sh files, plus references to those env vars in other files.