### PR TITLE
Minor improvements

### DIFF
--- a/pkg/build/cleanup.go
+++ b/pkg/build/cleanup.go
@@ -26,13 +26,20 @@ func NewDefaultCleaner(fs util.FileSystem, docker docker.Docker) Cleaner {
 // Cleanup removes the temporary directories where the sources were stored for build.
 func (c *DefaultCleaner) Cleanup(config *api.Config) {
 	if config.PreserveWorkingDir {
-		glog.Infof("Temporary directory '%s' will be saved, not deleted", config.WorkingDir)
+		glog.Infof("Temporary directory %q will be saved, not deleted", config.WorkingDir)
 	} else {
 		glog.V(2).Infof("Removing temporary directory %s", config.WorkingDir)
-		c.fs.RemoveDirectory(config.WorkingDir)
+		if err := c.fs.RemoveDirectory(config.WorkingDir); err != nil {
+			glog.Warningf("Error removing temporary directory %q: %v", config.WorkingDir, err)
+		}
 	}
 	if config.LayeredBuild {
+		// config.LayeredBuild is true only when layered build was finished successfully.
+		// Also in this case config.BuilderImage contains name of the new just built image,
+		// not the original one that was specified by the user.
 		glog.V(2).Infof("Removing temporary image %s", config.BuilderImage)
-		c.docker.RemoveImage(config.BuilderImage)
+		if err := c.docker.RemoveImage(config.BuilderImage); err != nil {
+			glog.Warningf("Error removing temporary image %s: %v", config.BuilderImage, err)
+		}
 	}
 }

--- a/pkg/build/strategies/onbuild/onbuild.go
+++ b/pkg/build/strategies/onbuild/onbuild.go
@@ -170,11 +170,11 @@ func (builder *OnBuild) copySTIScripts(config *api.Config) {
 	scriptsPath := filepath.Join(config.WorkingDir, "upload", "scripts")
 	sourcePath := filepath.Join(config.WorkingDir, "upload", "src")
 	if _, err := builder.fs.Stat(filepath.Join(scriptsPath, api.Run)); err == nil {
-		glog.V(3).Infof("Found S2I 'run' script, copying to application source dir")
+		glog.V(3).Info("Found S2I 'run' script, copying to application source dir")
 		builder.fs.Copy(filepath.Join(scriptsPath, api.Run), filepath.Join(sourcePath, api.Run))
 	}
 	if _, err := builder.fs.Stat(filepath.Join(scriptsPath, api.Assemble)); err == nil {
-		glog.V(3).Infof("Found S2I 'assemble' script, copying to application source dir")
+		glog.V(3).Info("Found S2I 'assemble' script, copying to application source dir")
 		builder.fs.Copy(filepath.Join(scriptsPath, api.Assemble), filepath.Join(sourcePath, api.Assemble))
 	}
 }

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -151,13 +151,13 @@ func (builder *STI) Build(config *api.Config) (*api.Result, error) {
 		}
 		glog.V(1).Infof("Existing image for tag %s detected for incremental build", tag)
 	} else {
-		glog.V(1).Infof("Clean build will be performed")
+		glog.V(1).Info("Clean build will be performed")
 	}
 
 	glog.V(2).Infof("Performing source build from %s", config.Source)
 	if builder.incremental {
 		if err := builder.artifacts.Save(config); err != nil {
-			glog.Warningf("Clean build will be performed because of error saving previous build artifacts")
+			glog.Warning("Clean build will be performed because of error saving previous build artifacts")
 			glog.V(2).Infof("error: %v", err)
 		}
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -553,7 +553,7 @@ func dumpContainerInfo(container *docker.Container, d *stiDocker, image string) 
 	cont, icerr := d.client.InspectContainer(container.ID)
 	liveports := "\n\nPort Bindings:  "
 	if icerr == nil {
-		//Ports is of the follwing type:  map[docker.Port][]docker.PortBinding
+		// Ports is of the following type:  map[docker.Port][]docker.PortBinding
 		for port, bindings := range cont.NetworkSettings.Ports {
 			liveports = liveports + "\n  Container Port:  " + port.Port()
 			liveports = liveports + "\n        Protocol:  " + port.Proto()
@@ -685,7 +685,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 		}
 		// Run PostExec hook if defined.
 		if opts.PostExec != nil {
-			glog.V(2).Infof("Invoking postExecution function")
+			glog.V(2).Info("Invoking PostExecute function")
 			if err = opts.PostExec.PostExecute(container.ID, tarDestination); err != nil {
 				return err
 			}

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -57,7 +57,7 @@ func GetImageRegistryAuth(auths *client.AuthConfigurations, imageName string) cl
 func LoadImageRegistryAuth(dockerCfg io.Reader) *client.AuthConfigurations {
 	auths, err := client.NewAuthConfigurations(dockerCfg)
 	if err != nil {
-		glog.Errorf("Unable to load docker config")
+		glog.Error("Unable to load docker config")
 		return nil
 	}
 	return auths
@@ -68,7 +68,7 @@ func LoadImageRegistryAuth(dockerCfg io.Reader) *client.AuthConfigurations {
 func LoadAndGetImageRegistryAuth(dockerCfg io.Reader, imageName string) client.AuthConfiguration {
 	auths, err := client.NewAuthConfigurations(dockerCfg)
 	if err != nil {
-		glog.Errorf("Unable to load docker config")
+		glog.Error("Unable to load docker config")
 		return client.AuthConfiguration{}
 	}
 	return GetImageRegistryAuth(auths, imageName)

--- a/pkg/scripts/environment.go
+++ b/pkg/scripts/environment.go
@@ -28,7 +28,7 @@ func GetEnvironment(config *api.Config) ([]Environment, error) {
 		if _, err := os.Stat(envPath); os.IsNotExist(err) {
 			return nil, errors.New("no environment file found in application sources")
 		}
-		glog.Infof("DEPRECATED: Use .s2i/environment instead of .sti/environment")
+		glog.Info("DEPRECATED: Use .s2i/environment instead of .sti/environment")
 	}
 
 	f, err := os.Open(envPath)

--- a/pkg/scripts/install.go
+++ b/pkg/scripts/install.go
@@ -120,7 +120,7 @@ func (s *SourceScriptHandler) Get(script string) *api.InstallResult {
 	// and this should (and will) be removed soon.
 	location = strings.Replace(location, "s2i/bin", "sti/bin", 1)
 	if s.fs.Exists(location) {
-		glog.Infof("DEPRECATED: Use .s2i/bin instead of .sti/bin")
+		glog.Info("DEPRECATED: Use .s2i/bin instead of .sti/bin")
 		return &api.InstallResult{Script: script, URL: location}
 	}
 	return nil

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -330,9 +330,9 @@ func (t *stiTar) ExtractTarStreamWithLogging(dir string, reader io.Reader, logge
 		select {
 		case err := <-errorChannel:
 			if err != nil {
-				glog.Errorf("Error extracting tar stream")
+				glog.Error("Error extracting tar stream")
 			} else {
-				glog.V(2).Infof("Done extracting tar stream")
+				glog.V(2).Info("Done extracting tar stream")
 			}
 			return err
 		case <-timeoutTimer.C:

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -41,7 +41,7 @@ func GenerateLabelsFromConfig(labels map[string]string, config *api.Config, name
 // informations.
 func GenerateLabelsFromSourceInfo(labels map[string]string, info *api.SourceInfo, namespace string) map[string]string {
 	if info == nil {
-		glog.V(3).Infof("Unable to fetch source informations, the output image labels will not be set")
+		glog.V(3).Info("Unable to fetch source informations, the output image labels will not be set")
 		return labels
 	}
 


### PR DESCRIPTION
- `pkg/docker/docker.go(dumpContainerInfo)`: fix a typo in comment
- `DefaultCleaner.Cleanup()`: add comment with explanation how it works
- Use `glog.Info` instead of `glog.Infof`
- `DefaultCleaner.Cleanup()`: show warnings when error happened
- `DefaultCleaner.Cleanup()`: use `%q` modifier
- `strategies/layered/layered.go(CreateDockerfile)`: use `--` for separating options from directories
- `strategies/layered/layered.go(CreateDockerfile)`: extract variable
- `strategies/layered/layered.go(CreateDockerfile)`: use variables instead of slice
- `pkg/build/strategies/layered/layered.go`: add missed bracket to comment

PTAL @bparees
CC @rhcarvalho 