### PR TITLE
Fix  passing of the arguments in our Logger implementation

### DIFF
--- a/pkg/util/glog/glog.go
+++ b/pkg/util/glog/glog.go
@@ -47,7 +47,7 @@ func (glogger) V(level int) Logger {
 }
 
 func (glogger) Infof(format string, args ...interface{}) {
-	glog.Infof(format, args)
+	glog.Infof(format, args...)
 }
 
 // gverbose handles glog.V(x) calls
@@ -67,7 +67,7 @@ func (gverbose) V(level int) Logger {
 }
 
 func (g gverbose) Infof(format string, args ...interface{}) {
-	g.Verbose.Infof(format, args)
+	g.Verbose.Infof(format, args...)
 }
 
 // file logs the provided messages at level or below to the writer, or delegates


### PR DESCRIPTION
Fix logging regression after #500

Before this patch:
```
I0519 17:35:08.051810 02152 glog.go:50] --> Uploading ["/tmp/s2i052311221/upload/scripts/run" "/tmp"] to %!q(MISSING) ...
```
After this patch:
```
I0519 17:42:06.734580 03500 glog.go:50] --> Uploading "/tmp/s2i886301399/upload/scripts/run" to "/tmp" ...
```

PTAL @bparees @smarterclayton 