### PR TITLE
Fix error message about retrieving previous image's metadata for non-incremental build

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -273,7 +273,10 @@ func mergeLabels(newLabels, existingLabels map[string]string) map[string]string 
 // finishes.
 func (builder *STI) PostExecute(containerID, location string) error {
 
-	previousImageID := builder.getPreviousImage()
+	var previousImageID string
+	if builder.incremental && builder.config.RemovePreviousImage {
+		previousImageID = builder.getPreviousImage()
+	}
 
 	buildEnv := builder.createBuildEnvironment()
 	runCmd := builder.createCommandForResultingImage(location)
@@ -299,7 +302,10 @@ func (builder *STI) PostExecute(containerID, location string) error {
 		glog.V(1).Infof("Successfully built %s", imageID)
 	}
 
-	builder.removePreviousImage(previousImageID)
+	if builder.incremental && builder.config.RemovePreviousImage {
+		builder.removePreviousImage(previousImageID)
+	}
+
 	builder.invokeCallbackUrl(labels)
 
 	return nil
@@ -308,7 +314,7 @@ func (builder *STI) PostExecute(containerID, location string) error {
 func (builder *STI) getPreviousImage() string {
 	previousImageID, err := builder.docker.GetImageID(builder.config.Tag)
 	if err != nil {
-		glog.V(0).Infof("error: Error retrieving previous image's metadata: %v", err)
+		glog.V(0).Infof("error: Error retrieving previous image's (%v) metadata: %v", builder.config.Tag, err)
 		return ""
 	}
 	return previousImageID
@@ -367,7 +373,7 @@ func (builder *STI) commitContainer(containerID, cmd, user string, env []string,
 }
 
 func (builder *STI) removePreviousImage(previousImageID string) {
-	if !builder.incremental || !builder.config.RemovePreviousImage || previousImageID == "" {
+	if previousImageID == "" {
 		return
 	}
 


### PR DESCRIPTION
Also include a tag of previous image to the message.

This is a fix for the small regression that was added in #501: it started to show error message:
```
error: Error retrieving previous image's metadata: no such image
```
But it didn't do anything else, so nothing was broken.

PTAL @bparees 