### PR TITLE
Pass --env variables to the build container

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -452,7 +452,7 @@ func (e *EnvironmentList) Set(value string) error {
 		return fmt.Errorf("invalid environment format %q, must be NAME=VALUE", value)
 	}
 	if strings.Contains(parts[1], ",") && strings.Contains(parts[1], "=") {
-		glog.Warningf("DEPRECATED: Use multiple -e flags to specify multiple environment variables instead of comma (%q)", parts[1])
+		glog.Warningf("DEPRECATED: Use multiple -e flags to specify multiple environment variables instead of comma (%q)", value)
 	}
 	*e = append(*e, EnvironmentSpec{
 		Name:  strings.TrimSpace(parts[0]),

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -317,7 +317,6 @@ func (builder *STI) createBuildEnvironment() []string {
 	env, err := scripts.GetEnvironment(builder.config)
 	if err != nil {
 		glog.V(1).Infof("No user environment provided (%v)", err)
-		return nil
 	}
 
 	return append(scripts.ConvertEnvironment(env), builder.generateConfigEnv()...)

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -758,6 +758,11 @@ func TestExecuteOK(t *testing.T) {
 	rh.config.WorkingDir = "/working-dir"
 	rh.config.BuilderImage = "test/image"
 	rh.config.BuilderPullPolicy = api.PullAlways
+	rh.config.Environment = api.EnvironmentList{
+		api.EnvironmentSpec{"Key1", "Value1"},
+		api.EnvironmentSpec{"Key2", "Value2"},
+	}
+	expectedEnv := []string{"Key1=Value1", "Key2=Value2"}
 	th := rh.tar.(*test.FakeTar)
 	th.CreateTarResult = "/working-dir/test.tar"
 	fd := rh.docker.(*docker.FakeDocker)
@@ -807,6 +812,9 @@ func TestExecuteOK(t *testing.T) {
 	if pe.PostExecuteContainerID != "1234" {
 		t.Errorf("PostExecutor not called with expected ID: %s",
 			pe.PostExecuteContainerID)
+	}
+	if !reflect.DeepEqual(ro.Env, expectedEnv) {
+		t.Errorf("Unexpected container environment passed to RunContainer: %v, should be %v", ro.Env, expectedEnv)
 	}
 	if !reflect.DeepEqual(pe.PostExecuteDestination, "test-command") {
 		t.Errorf("PostExecutor not called with expected command: %s", pe.PostExecuteDestination)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/openshift/source-to-image/pull/501

@bparees @php-coder