### PR TITLE
Minor improvements

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -130,7 +130,7 @@ type Config struct {
 	// CallbackURL is a URL which is called upon successful build to inform about that fact.
 	CallbackURL string
 
-	// ScriptsURL is a URL describing the localization of STI scripts used during build process.
+	// ScriptsURL is a URL describing the localization of S2I scripts used during build process.
 	ScriptsURL string
 
 	// Destination specifies a location where the untar operation will place its artifacts.
@@ -410,10 +410,11 @@ func IsInvalidFilename(name string) bool {
 // When the destination is not specified, the source get copied into current
 // working directory in container.
 func (l *VolumeList) Set(value string) error {
+	if len(value) == 0 {
+		return fmt.Errorf("invalid format, must be source:destination")
+	}
 	mount := strings.Split(value, ":")
 	switch len(mount) {
-	case 0:
-		return fmt.Errorf("invalid format, must be source:destination")
 	case 1:
 		mount = append(mount, "")
 		fallthrough

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -203,7 +203,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 		}
 	}
 
-	// fetch sources, for their .sti/bin might contain sti scripts
+	// fetch sources, for their .s2i/bin might contain s2i scripts
 	if len(config.Source) > 0 {
 		if builder.sourceInfo, err = builder.source.Download(config); err != nil {
 			return err

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -365,12 +365,12 @@ func TestPostExecute(t *testing.T) {
 			t.Errorf("(%d) Unexpected commit container command: %#v, expected %q", i, dh.CommitContainerOpts.Command, expectedCmd)
 		}
 		if dh.CommitContainerOpts.Repository != tc.tag {
-			t.Errorf("(%d) Unexpected tag commited, expected %s, got %s", i, tc.tag, dh.CommitContainerOpts.Repository)
+			t.Errorf("(%d) Unexpected tag commited, expected %q, got %q", i, tc.tag, dh.CommitContainerOpts.Repository)
 		}
 		// Ensure image removal when incremental and previousImageID present
 		if tc.incremental && tc.previousImageID != "" {
 			if dh.RemoveImageName != "test-image" {
-				t.Errorf("(%d) Previous image was not removed: %s", i, dh.RemoveImageName)
+				t.Errorf("(%d) Previous image was not removed: %q", i, dh.RemoveImageName)
 			}
 		} else {
 			if dh.RemoveImageName != "" {
@@ -379,7 +379,7 @@ func TestPostExecute(t *testing.T) {
 		}
 		// Ensure Callback was called
 		if ci.CallbackURL != bh.config.CallbackURL {
-			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %s", i, bh.config.CallbackURL, ci.CallbackURL)
+			t.Errorf("(%d) Unexpected callbackURL, expected %q, got %q", i, bh.config.CallbackURL, ci.CallbackURL)
 		}
 	}
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -30,7 +30,7 @@ const (
 	LocationEnvironment = "STI_LOCATION"
 
 	// ScriptsURLLabel is the name of the Docker image LABEL that tells S2I where
-	// to look for the S2I scripts. This label is also copied into the ouput
+	// to look for the S2I scripts. This label is also copied into the output
 	// image.
 	// The previous name of this label was 'io.s2i.scripts-url'. This is now
 	// deprecated.
@@ -445,7 +445,7 @@ func getVariable(image *docker.Image, name string) string {
 	return ""
 }
 
-// GetScriptsURL finds a scripts-url label in the given image's metadata
+// GetScriptsURL finds a scripts-url label on the given image.
 func (d *stiDocker) GetScriptsURL(image string) (string, error) {
 	imageMetadata, err := d.CheckAndPullImage(image)
 	if err != nil {
@@ -463,20 +463,21 @@ func getScriptsURL(image *docker.Image) string {
 	if len(scriptsURL) == 0 {
 		scriptsURL = getLabel(image, "io.s2i.scripts-url")
 		if len(scriptsURL) > 0 {
-			glog.V(0).Infof("warning: The 'io.s2i.scripts-url' label is deprecated. Use %q instead.", ScriptsURLLabel)
+			glog.V(0).Infof("warning: Image %s uses deprecated label 'io.s2i.scripts-url', please migrate it to %s instead!",
+				image.ID, ScriptsURLLabel)
 		}
 	}
 	if len(scriptsURL) == 0 {
 		scriptsURL = getVariable(image, ScriptsURLEnvironment)
 		if len(scriptsURL) != 0 {
-			glog.V(0).Infof("warning: BuilderImage uses deprecated environment variable %s, please migrate it to %s label instead!",
-				ScriptsURLEnvironment, ScriptsURLLabel)
+			glog.V(0).Infof("warning: Image %s uses deprecated environment variable %s, please migrate it to %s label instead!",
+				image.ID, ScriptsURLEnvironment, ScriptsURLLabel)
 		}
 	}
 	if len(scriptsURL) == 0 {
-		glog.V(0).Infof("warning: Image does not contain a value for the %s label", ScriptsURLLabel)
+		glog.V(0).Infof("warning: Image %s does not contain a value for the %s label", image.ID, ScriptsURLLabel)
 	} else {
-		glog.V(2).Infof("Image contains %s set to '%s'", ScriptsURLLabel, scriptsURL)
+		glog.V(2).Infof("Image %s contains %s set to %q", image.ID, ScriptsURLLabel, scriptsURL)
 	}
 
 	return scriptsURL
@@ -489,12 +490,13 @@ func getDestination(image *docker.Image) string {
 	}
 	// For backward compatibility, support the old label schema
 	if val := getLabel(image, "io.s2i.destination"); len(val) != 0 {
-		glog.V(0).Infof("warning: The 'io.s2i.destination' label is deprecated. Use %q instead.", DestinationLabel)
+		glog.V(0).Infof("warning: Image %s uses deprecated label 'io.s2i.destination', please migrate it to %s instead!",
+			image.ID, DestinationLabel)
 		return val
 	}
 	if val := getVariable(image, LocationEnvironment); len(val) != 0 {
-		glog.V(0).Infof("warning: BuilderImage uses deprecated environment variable %s, please migrate it to %s label instead!",
-			LocationEnvironment, DestinationLabel)
+		glog.V(0).Infof("warning: Image %s uses deprecated environment variable %s, please migrate it to %s label instead!",
+			image.ID, LocationEnvironment, DestinationLabel)
 		return val
 	}
 

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -91,7 +91,7 @@ func (t *stiTar) SetExclusionPattern(p *regexp.Regexp) {
 	t.exclude = p
 }
 
-// StreamFileAsTar streams the source directory as a tar archive.
+// StreamDirAsTar streams the source directory as a tar archive.
 // The permissions of the file is changed to 0666.
 func (t *stiTar) StreamDirAsTar(source, dest string, writer io.Writer) error {
 	f, err := os.Open(source)

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -91,18 +91,18 @@ func (h *fs) Copy(source string, dest string) (err error) {
 	if err != nil {
 		return err
 	}
+	defer sourcefile.Close()
 	sourceinfo, err := os.Stat(source)
 	if err != nil {
 		return err
 	}
-	defer sourcefile.Close()
 
 	if sourceinfo.IsDir() {
 		glog.V(5).Infof("D %q -> %q", source, dest)
 		return h.CopyContents(source, dest)
 	}
 
-	destinfo, err := os.Stat(dest)
+	destinfo, _ := os.Stat(dest)
 	if destinfo != nil && destinfo.IsDir() {
 		return fmt.Errorf("destination must be full path to a file, not directory")
 	}


### PR DESCRIPTION
A set of minor improvements:
- `VolumeList.Set()`: raise error for an empty string
- `fs.Copy()`: fix possible fd leak and explicitly ignore err
- `docker.GetScriptsURL()`: unify error messages and show image id
- improves error messages in some tests
- replaces sti by s2i in some places
- fixes a couple of typos
- improves godoc

PTAL @bparees 