### PR TITLE
Migrating s2i to use glog mock library

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/golang/glog"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	"github.com/openshift/source-to-image/pkg/util/user"
 )
+
+var glog = utilglog.StderrLog
 
 // Image label namespace constants
 const (

--- a/pkg/build/cleanup.go
+++ b/pkg/build/cleanup.go
@@ -1,11 +1,13 @@
 package build
 
 import (
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // DefaultCleaner provides a cleaner for most STI build use-cases. It cleans the
 // temporary directories created by STI build and it also cleans the temporary

--- a/pkg/build/strategies/layered/layered.go
+++ b/pkg/build/strategies/layered/layered.go
@@ -12,14 +12,16 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 const defaultDestination = "/tmp"
 
@@ -188,7 +190,7 @@ func (builder *Layered) Build(config *api.Config) (*api.Result, error) {
 			if err != nil {
 				// we're ignoring ErrClosedPipe, as this is information
 				// the docker container ended streaming logs
-				if glog.V(2) && err != io.ErrClosedPipe && err != io.EOF {
+				if glog.Is(2) && err != io.ErrClosedPipe && err != io.EOF {
 					glog.Errorf("Error reading docker stdout, %v", err)
 				}
 				break

--- a/pkg/build/strategies/onbuild/entrypoint.go
+++ b/pkg/build/strategies/onbuild/entrypoint.go
@@ -5,9 +5,11 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 var validEntrypoints = []*regexp.Regexp{
 	regexp.MustCompile(`^run(\.sh)?$`),

--- a/pkg/build/strategies/onbuild/onbuild.go
+++ b/pkg/build/strategies/onbuild/onbuild.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/build/strategies/sti"

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/build/strategies/layered"
@@ -23,7 +22,10 @@ import (
 	"github.com/openshift/source-to-image/pkg/scripts"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 var (
 	// List of directories that needs to be present inside working dir
@@ -293,7 +295,7 @@ func (builder *STI) PostExecute(containerID, location string) error {
 	builder.result.Success = true
 	builder.result.ImageID = imageID
 
-	glog.V(1).Infof("Successfully built %s", firstNonEmpty(builder.config.Tag, imageID))
+	glog.V(3).Infof("Successfully built %s", firstNonEmpty(builder.config.Tag, imageID))
 
 	if builder.incremental && builder.config.RemovePreviousImage {
 		builder.removePreviousImage(previousImageID)
@@ -316,7 +318,7 @@ func (builder *STI) getPreviousImage() string {
 func (builder *STI) createBuildEnvironment() []string {
 	env, err := scripts.GetEnvironment(builder.config)
 	if err != nil {
-		glog.V(1).Infof("No user environment provided (%v)", err)
+		glog.V(3).Infof("No user environment provided (%v)", err)
 	}
 
 	return append(scripts.ConvertEnvironment(env), builder.generateConfigEnv()...)
@@ -584,12 +586,14 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 
 	go func(reader io.Reader) {
 		scanner := bufio.NewReader(reader)
+		// Precede build output with newline
+		glog.Info()
 		for {
 			text, err := scanner.ReadString('\n')
 			if err != nil {
 				// we're ignoring ErrClosedPipe, as this is information
 				// the docker container ended streaming logs
-				if glog.V(2) && err != io.ErrClosedPipe && err != io.EOF {
+				if glog.Is(2) && err != io.ErrClosedPipe && err != io.EOF {
 					glog.Errorf("Error reading docker stdout, %v", err)
 				}
 				break
@@ -598,13 +602,11 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 			if config.Quiet {
 				continue
 			}
-			// The log level > 3 forces to use glog instead of printing to stdout
-			if glog.V(3) {
-				glog.Info(text)
-				continue
-			}
-			fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(text))
+			glog.Info(strings.TrimSpace(text))
 		}
+		// Terminate build output with new line
+		glog.Info()
+
 	}(outReader)
 
 	go dockerpkg.StreamContainerIO(errReader, &errOutput, glog.Error)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,11 +5,13 @@ import (
 
 	"encoding/json"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+var glog = utilglog.StderrLog
 
 // DefaultConfigPath specifies the default location of the S2I config file
 const DefaultConfigPath = ".s2ifile"

--- a/pkg/create/create.go
+++ b/pkg/create/create.go
@@ -5,9 +5,11 @@ import (
 	"runtime"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/create/templates"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // Bootstrap defines parameters for the template processing
 type Bootstrap struct {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -390,7 +390,7 @@ func (d *stiDocker) CheckAndPullImage(name string) (*docker.Image, error) {
 		return d.PullImage(name)
 	}
 
-	glog.V(1).Infof("Using locally available image %q", displayName)
+	glog.V(3).Infof("Using locally available image %q", displayName)
 	return image, nil
 }
 

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -19,7 +19,7 @@ import (
 
 // glog is a placeholder until the builders pass an output stream down
 // client facing libraries should not be using glog
-var glog = utilglog.ToFile(os.Stderr, 2)
+var glog = utilglog.StderrLog
 
 // ImageReference points to a Docker image.
 type ImageReference struct {

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 type DockerIgnorer struct{}
 

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -5,11 +5,13 @@ package run
 import (
 	"io"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // A DockerRunner allows running a Docker image as a new container, streaming
 // stdout and stderr with glog.

--- a/pkg/scm/empty/noop.go
+++ b/pkg/scm/empty/noop.go
@@ -1,9 +1,11 @@
 package empty
 
 import (
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // Noop is for build configs with an empty Source definition, where
 // the assemble script is responsible for retrieving source

--- a/pkg/scm/file/download.go
+++ b/pkg/scm/file/download.go
@@ -4,10 +4,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // File represents a simplest possible Downloader implementation where the
 // sources are just copied from local directory.

--- a/pkg/scm/git/clone.go
+++ b/pkg/scm/git/clone.go
@@ -3,7 +3,6 @@ package git
 import (
 	"path/filepath"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/util"

--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -12,10 +12,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/util"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // Git is an interface used by main STI code to extract/checkout git repositories
 type Git interface {

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -3,7 +3,7 @@ package scm
 import (
 	"fmt"
 
-	"github.com/golang/glog"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/scm/empty"
@@ -11,6 +11,8 @@ import (
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/util"
 )
+
+var glog = utilglog.StderrLog
 
 // DownloaderForSource determines what SCM plugin should be used for downloading
 // the sources from the repository.

--- a/pkg/scripts/download.go
+++ b/pkg/scripts/download.go
@@ -7,11 +7,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/errors"
 )
+
+var glog = utilglog.StderrLog
 
 // Downloader downloads the specified URL to the target file location
 type Downloader interface {

--- a/pkg/scripts/environment.go
+++ b/pkg/scripts/environment.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 )
 

--- a/pkg/scripts/install.go
+++ b/pkg/scripts/install.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	dockerClient "github.com/fsouza/go-dockerclient"
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -11,11 +11,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/golang/glog"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	"github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/util"
 )
+
+var glog = utilglog.StderrLog
 
 // defaultTimeout is the amount of time that the untar will wait for a tar
 // stream to extract a single file. A timeout is needed to guard against broken

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -8,10 +8,12 @@ import (
 	"path"
 	"runtime"
 
-	"github.com/golang/glog"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	"github.com/openshift/source-to-image/pkg/errors"
 )
+
+var glog = utilglog.StderrLog
 
 // FileSystem allows STI to work with the file system and
 // perform tasks such as creating and deleting directories

--- a/pkg/util/glog/glog.go
+++ b/pkg/util/glog/glog.go
@@ -1,101 +1,176 @@
 package glog
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
-	"github.com/golang/glog"
+	log "github.com/golang/glog"
 )
 
 // Logger is a simple interface that is roughly equivalent to glog.
 type Logger interface {
-	Is(level int) bool
-	V(level int) Logger
+	Is(level int32) bool
+	V(level int32) VerboseLogger
 	Infof(format string, args ...interface{})
+	Info(args ...interface{})
+	Warningf(format string, args ...interface{})
+	Warning(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatal(args ...interface{})
+}
+
+// VerboseLogger is roughly equivalent to glog's Verbose.
+type VerboseLogger interface {
+	Infof(format string, args ...interface{})
+	Info(args ...interface{})
 }
 
 // ToFile creates a logger that will log any items at level or below to file, and defer
-// any other output to glog (no matter what the level is.)
-func ToFile(w io.Writer, level int) Logger {
-	return file{w, level}
+// any other output to glog (no matter what the level is).
+func ToFile(x io.Writer, level int32) Logger {
+	return &FileLogger{
+		bufio.NewWriter(x),
+		level,
+	}
 }
 
 var (
-	// None implements the Logger interface but does nothing with the log output
+	// None implements the Logger interface but does nothing with the log output.
 	None Logger = discard{}
-	// Log implements the Logger interface for Glog
-	Log Logger = glogger{}
+	// StderrLog implements the Logger interface for stderr.
+	StderrLog = ToFile(os.Stderr, 2)
 )
 
 // discard is a Logger that outputs nothing.
 type discard struct{}
 
-func (discard) Is(level int) bool                { return false }
-func (discard) V(level int) Logger               { return None }
-func (discard) Infof(_ string, _ ...interface{}) {}
+func (discard) Is(level int32) bool                    { return false }
+func (discarding discard) V(level int32) VerboseLogger { return discarding }
+func (discard) Infof(_ string, _ ...interface{})       {}
+func (discard) Info(_ ...interface{})                  {}
+func (discard) Errorf(_ string, _ ...interface{})      {}
+func (discard) Error(_ ...interface{})                 {}
+func (discard) Warningf(_ string, _ ...interface{})    {}
+func (discard) Warning(_ ...interface{})               {}
+func (discard) Fatalf(_ string, _ ...interface{})      {}
+func (discard) Fatal(_ ...interface{})                 {}
 
-// glogger outputs log messages to glog
-type glogger struct{}
-
-func (glogger) Is(level int) bool {
-	return bool(glog.V(glog.Level(level)))
-}
-
-func (glogger) V(level int) Logger {
-	return gverbose{glog.V(glog.Level(level))}
-}
-
-func (glogger) Infof(format string, args ...interface{}) {
-	glog.Infof(format, args...)
-}
-
-// gverbose handles glog.V(x) calls
-type gverbose struct {
-	glog.Verbose
-}
-
-func (gverbose) Is(level int) bool {
-	return bool(glog.V(glog.Level(level)))
-}
-
-func (gverbose) V(level int) Logger {
-	if glog.V(glog.Level(level)) {
-		return Log
-	}
-	return None
-}
-
-func (g gverbose) Infof(format string, args ...interface{}) {
-	g.Verbose.Infof(format, args...)
-}
-
-// file logs the provided messages at level or below to the writer, or delegates
+// FileLogger logs the provided messages at level or below to the writer, or delegates
 // to glog.
-type file struct {
-	w     io.Writer
-	level int
+type FileLogger struct {
+	w     *bufio.Writer
+	level int32
 }
 
-func (f file) Is(level int) bool {
+// Is returns whether the current logging level is greater than or equal to the parameter.
+func (f *FileLogger) Is(level int32) bool {
 	return level <= f.level
 }
 
-func (f file) V(level int) Logger {
-	// only log things that glog allows
-	if !glog.V(glog.Level(level)) {
-		return None
+// V will returns a logger which will discard output if the specified level is greater than the current logging level.
+func (f *FileLogger) V(level int32) VerboseLogger {
+	// Is the loglevel set verbose enough to accept the forthcoming log statement
+	if log.V(log.Level(level)) {
+		return f
 	}
-	// send anything above our level to glog
-	if level > f.level {
-		return Log
-	}
-	return f
+	// Otherwise discard
+	return None
 }
 
-func (f file) Infof(format string, args ...interface{}) {
-	fmt.Fprintf(f.w, format, args...)
-	if !strings.HasSuffix(format, "\n") {
-		fmt.Fprintln(f.w)
+type severity int32
+
+const (
+	infoLog severity = iota
+	warningLog
+	errorLog
+	fatalLog
+)
+
+// Elevated logger methods output a detailed prefix for each logging statement.
+// At present, we delegate to glog to accomplish this.
+type elevated func(int, ...interface{})
+
+type severityDetail struct {
+	prefix     string
+	delegateFn elevated
+}
+
+var severities = []severityDetail{
+	infoLog:    {"", log.InfoDepth},
+	warningLog: {"WARNING: ", log.WarningDepth},
+	errorLog:   {"ERROR: ", log.ErrorDepth},
+	fatalLog:   {"FATAL: ", log.FatalDepth},
+}
+
+func (f *FileLogger) writeln(sev severity, line string) {
+	severity := severities[sev]
+
+	// If the loglevel has been elevated above this file logger's verbosity (generally set to 2)
+	// then delegate ALL messages to elevated logger in order to leverage its file/line/timestamp
+	// prefix information.
+	if log.V(log.Level(f.level + 1)) {
+		severity.delegateFn(3, line)
+	} else {
+		defer f.w.Flush()
+		f.w.WriteString(severity.prefix)
+		f.w.WriteString(line)
+		if !strings.HasSuffix(line, "\n") {
+			f.w.WriteByte('\n')
+		}
 	}
+}
+
+func (f *FileLogger) outputf(sev severity, format string, args ...interface{}) {
+	f.writeln(sev, fmt.Sprintf(format, args...))
+}
+
+func (f *FileLogger) output(sev severity, args ...interface{}) {
+	f.writeln(sev, fmt.Sprint(args...))
+}
+
+// Infof records an info log entry.
+func (f *FileLogger) Infof(format string, args ...interface{}) {
+	f.outputf(infoLog, format, args...)
+}
+
+// Info records an info log entry.
+func (f *FileLogger) Info(args ...interface{}) {
+	f.output(infoLog, args...)
+}
+
+// Warningf records an warning log entry.
+func (f *FileLogger) Warningf(format string, args ...interface{}) {
+	f.outputf(warningLog, format, args...)
+}
+
+// Warning records an warning log entry.
+func (f *FileLogger) Warning(args ...interface{}) {
+	f.output(warningLog, args...)
+}
+
+// Errorf records an error log entry.
+func (f *FileLogger) Errorf(format string, args ...interface{}) {
+	f.outputf(errorLog, format, args...)
+}
+
+// Error records an error log entry.
+func (f *FileLogger) Error(args ...interface{}) {
+	f.output(errorLog, args...)
+}
+
+// Fatalf records a fatal log entry and terminates the program.
+func (f *FileLogger) Fatalf(format string, args ...interface{}) {
+	defer os.Exit(1)
+	f.outputf(fatalLog, format, args...)
+}
+
+// Fatal records a fatal log entry and terminates the program.
+func (f *FileLogger) Fatal(args ...interface{}) {
+	defer os.Exit(1)
+	f.output(fatalLog, args...)
 }

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 )
 

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/api"
 )
 


### PR DESCRIPTION
@smarterclayton @bparees @csrwng 

- Added additional methods to glog mock util to limit impact when porting other libraries currently using standard glog
- Add flushing to file based loggers (doesn't really matter for stderr, but if you changed to use a real file, it could)

Question: I tied --loglevel to the level maintained by the toFile logger created by toFile. This obviates some of the logic of pkg/util/glog.go:V(int32) because file.level will always match vanilla golog's Level. That is, V(#) will never decide to send user output to standard glog instead of the file output.

The alternative, leaving toFile's file.level at a constant 2, didn't seem like a useful notion here *unless* you want golog's prefix to be included on Info and above. However, even if you did, the stack element would be useless, because it would always point to pkg/util/glog.go .