### PR TITLE
Fix some nits in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For a dynamic language like Ruby, the build-time and run-time environments are t
 1. The container process transforms that source code into the appropriate runnable setup - in this case, by installing dependencies with Bundler and moving the source code into a directory where Apache has been preconfigured to look for the Ruby `config.ru` file.
 1. Commit the new container and set the image entrypoint to be a script (provided by the builder image) that will start Apache to host the Ruby application.
 
-For compiled languages like Java, C, or Golang, the dependencies necessary for compilation might dramatically outweigh the actual runtime artifacts. To keep runtime images slim, S2I enables a multiple-step build processes, where a binary artifact such as an executable or Java WAR file is created in the first builder image, extracted, and injected into a second runtime image that simply places the executable in the correct location for execution.
+For compiled languages like C, C++, Go, or Java, the dependencies necessary for compilation might dramatically outweigh the size of the actual runtime artifacts. To keep runtime images slim, S2I enables a multiple-step build processes, where a binary artifact such as an executable or Java WAR file is created in the first builder image, extracted, and injected into a second runtime image that simply places the executable in the correct location for execution.
 
 For example, to create a reproducible build pipeline for Tomcat (the popular Java webserver) and Maven:
 
@@ -38,7 +38,7 @@ Learn more about [building your own images](#getting-started) and [how to use a 
 Allow build environments to be tightly versioned by encapsulating them within a Docker image and defining a simple interface (injected source code) for callers. Reproducible builds are a key requirement to enabling security updates and continuous integration in containerized infrastructure, and builder images help ensure repeatability as well as the ability to swap runtimes.
 
 ### Flexibility
-Any existing build system that can run on Linux can be run inside of a container, and each individual builder can also be part of a larger pipeline. In addition, the scripts that process the application source code can be injected into the builder image, allowing authors to adapt existing images to enable source handling. 
+Any existing build system that can run on Linux can be run inside of a container, and each individual builder can also be part of a larger pipeline. In addition, the scripts that process the application source code can be injected into the builder image, allowing authors to adapt existing images to enable source handling.
 
 ### Speed   
 Instead of building multiple layers in a single Dockerfile, S2I encourages authors to represent an application in a single image layer. This saves time during creation and deployment, and allows for better control over the output of the final image.
@@ -172,21 +172,21 @@ If a `save-artifacts` script exists, a prior image already exists, and the `--in
 
 Go to the [releases](https://github.com/openshift/source-to-image/releases/latest) page and download the correct distribution for your machine.  If on a Mac, use the darwin-amd64 link.  If on Linux, choose either the linux-386 or the linux-amd64 links for 32 and 64-bit, respectively.
 
-Unpack the downloaded tar with 
+Unpack the downloaded tar with
 
 ```$ tar -xvf release.tar.gz```.
 
 You should now see an executable called s2i.  Either add the location of s2i to your PATH environment variable, or move it to a pre-existing directory in your PATH.
-For example, 
+For example,
 
-```# cp /path/to/s2i /usr/local/bin``` 
+```# cp /path/to/s2i /usr/local/bin```
 
 will work with most setups.
 
 ##### For Windows
 
 Download the latest [64-bit Windows release](https://github.com/openshift/source-to-image/releases/latest).
-Extract the zip file through a file browser.  Add the extracted directory to your PATH.  You can now use 
+Extract the zip file through a file browser.  Add the extracted directory to your PATH.  You can now use
 s2i from the command line.
 
 ##### From source

--- a/docs/runtime_image.md
+++ b/docs/runtime_image.md
@@ -4,7 +4,7 @@
 
 For dynamic languages like PHP, Python, or Ruby, the build-time and run-time environments are the same. In this case using the builder as a base image for a resulting application image is natural.
 
-For compiled languages like C/C++, Java, or Golang, the dependencies necessary for compilation might dramatically outweigh the size of the actual runtime artifacts, or provide attack surface areas that are undesirable in an application image. To keep runtime images slim, S2I enables a multiple-step build processes, where a binary artifact such as an executable or Java WAR file is created in the first builder image, extracted, and injected into an second image that simply places the executable in the correct location for execution. To give you even more abilities to customize a resulting image, S2I is also executing an `assemble-runtime` script inside of this (runtime) image. In this way you may do final adjustments by modifying files before an image will be committed.
+For compiled languages like C, C++, Go, or Java, the dependencies necessary for compilation might dramatically outweigh the size of the actual runtime artifacts, or provide attack surface areas that are undesirable in an application image. To keep runtime images slim, S2I enables a multiple-step build processes, where a binary artifact such as an executable or Java WAR file is created in the first builder image, extracted, and injected into a second image that simply places the executable in the correct location for execution. To give you even more abilities to customize a resulting image, S2I is also executing an `assemble-runtime` script inside of this (runtime) image. In this way you may do final adjustments by modifying files before an image will be committed.
 
 The following diagram illustrates the build workflow:
 
@@ -84,4 +84,3 @@ Builder and runtime containers have the same environment. In other words `assemb
 ### Extended build and incremental build
 
 In the current implementation it is not possible to do an extended incremental build. This combination is invalid and the build will fail.
-


### PR DESCRIPTION
- s/Golang/Go/
- Make similar paragraphs similar, include the same list of languages.
  The paragraph in docs/runtime_image.md contains more detailed
  information.
- Spurious whitespace changes.