### PR TITLE
override entrypoint to env during assemble

### DIFF
--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -83,7 +83,7 @@ func DescribeConfig(config *api.Config) string {
 		return nil
 	})
 	if err != nil {
-		fmt.Printf("ERROR: %v", err)
+		fmt.Printf("error: %v", err)
 	}
 	return out
 }

--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/api"
 	dockerpkg "github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/run"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
 )
@@ -53,10 +54,10 @@ type storePreviousImageStep struct {
 
 func (step *storePreviousImageStep) execute(ctx *postExecutorStepContext) error {
 	if step.builder.incremental && step.builder.config.RemovePreviousImage {
-		glog.V(3).Info("Executing step: remember previous image")
+		glog.V(3).Info("Executing step: store previous image")
 		ctx.previousImageID = step.getPreviousImage()
 	} else {
-		glog.V(3).Info("Skipping step: remember previous image")
+		glog.V(3).Info("Skipping step: store previous image")
 	}
 	return nil
 }
@@ -114,7 +115,19 @@ func (step *commitImageStep) execute(ctx *postExecutorStepContext) error {
 
 	ctx.labels = createLabelsForResultingImage(step.builder, step.docker, step.image)
 
-	ctx.imageID, err = commitContainer(step.docker, ctx.containerID, cmd, user, step.builder.config.Tag, step.builder.env, ctx.labels)
+	// Set the image entrypoint back to its original value on commit, the running
+	// container has "env" as its entrypoint and we don't want to commit that.
+	entrypoint, err := step.docker.GetImageEntrypoint(step.image)
+	if err != nil {
+		return fmt.Errorf("Couldn't get entrypoint of %q image: %v", step.image, err)
+	}
+	// If the image has no explicit entrypoint, set it to an empty array
+	// so we don't default to leaving the entrypoint as "env" upon commit.
+	if entrypoint == nil {
+		entrypoint = []string{}
+	}
+
+	ctx.imageID, err = commitContainer(step.docker, ctx.containerID, cmd, user, step.builder.config.Tag, step.builder.env, entrypoint, ctx.labels)
 	if err != nil {
 		return err
 	}
@@ -261,6 +274,7 @@ func (step *startRuntimeImageAndUploadFilesStep) execute(ctx *postExecutorStepCo
 
 	opts := dockerpkg.RunContainerOptions{
 		Image:           image,
+		Entrypoint:      run.DefaultEntrypoint,
 		PullImage:       false, // The PullImage is false because we've already pulled the image
 		CommandExplicit: []string{"/bin/sh", "-c", cmd},
 		Stdout:          outWriter,
@@ -369,10 +383,11 @@ func (step *invokeCallbackStep) execute(ctx *postExecutorStepContext) error {
 
 // shared methods
 
-func commitContainer(docker dockerpkg.Docker, containerID, cmd, user, tag string, env []string, labels map[string]string) (string, error) {
+func commitContainer(docker dockerpkg.Docker, containerID, cmd, user, tag string, env, entrypoint []string, labels map[string]string) (string, error) {
 	opts := dockerpkg.CommitContainerOptions{
 		Command:     []string{cmd},
 		Env:         env,
+		Entrypoint:  entrypoint,
 		ContainerID: containerID,
 		Repository:  tag,
 		User:        user,

--- a/pkg/build/strategies/sti/postexecutorstep_test.go
+++ b/pkg/build/strategies/sti/postexecutorstep_test.go
@@ -124,6 +124,7 @@ func TestCommitImageStep(t *testing.T) {
 		expectedImageID := "image-xxx"
 		expectedImageTag := "v1"
 		expectedImageUser := "jboss"
+		expectedEntrypoint := []string{"test_entrypoint"}
 
 		displayName := "MyApp"
 		description := "My Application is awesome!"
@@ -145,6 +146,7 @@ func TestCommitImageStep(t *testing.T) {
 		docker := builder.docker.(*docker.FakeDocker)
 		docker.CommitContainerResult = expectedImageID
 		docker.GetImageUserResult = expectedImageUser
+		docker.GetImageEntrypointResult = expectedEntrypoint
 		docker.Labels = baseImageLabels
 
 		ctx := &postExecutorStepContext{
@@ -191,6 +193,10 @@ func TestCommitImageStep(t *testing.T) {
 
 		if commitOpts.User != expectedImageUser {
 			t.Errorf("should commit container with User: %q, but commited with %q", expectedImageUser, commitOpts.User)
+		}
+
+		if !reflect.DeepEqual(commitOpts.Entrypoint, expectedEntrypoint) {
+			t.Errorf("should commit container with Entrypoint: %q, but commited with %q", expectedEntrypoint, commitOpts.Entrypoint)
 		}
 
 		if !reflect.DeepEqual(commitOpts.Labels, expectedLabels) {

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -17,6 +17,7 @@ import (
 	dockerpkg "github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/ignore"
+	"github.com/openshift/source-to-image/pkg/run"
 	"github.com/openshift/source-to-image/pkg/scm"
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/scripts"
@@ -322,8 +323,8 @@ func (builder *STI) SetScripts(required, optional []string) {
 	builder.optionalScripts = optional
 }
 
-// PostExecute allows to execute post-build actions after the Docker build
-// finishes.
+// PostExecute allows to execute post-build actions after the Docker
+// container execution finishes.
 func (builder *STI) PostExecute(containerID, destination string) error {
 	builder.postExecutorStepsContext.containerID = containerID
 	builder.postExecutorStepsContext.destination = destination
@@ -411,6 +412,7 @@ func (builder *STI) Save(config *api.Config) (err error) {
 	opts := dockerpkg.RunContainerOptions{
 		Image:           image,
 		User:            user,
+		Entrypoint:      run.DefaultEntrypoint,
 		ExternalScripts: builder.externalScripts[api.SaveArtifacts],
 		ScriptsURL:      config.ScriptsURL,
 		Destination:     config.Destination,
@@ -454,9 +456,10 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 	}
 
 	opts := dockerpkg.RunContainerOptions{
-		Image:  config.BuilderImage,
-		Stdout: outWriter,
-		Stderr: errWriter,
+		Image:      config.BuilderImage,
+		Entrypoint: run.DefaultEntrypoint,
+		Stdout:     outWriter,
+		Stderr:     errWriter,
 		// The PullImage is false because the PullImage function should be called
 		// before we run the container
 		PullImage:       false,

--- a/pkg/docker/fake_docker.go
+++ b/pkg/docker/fake_docker.go
@@ -31,6 +31,8 @@ type FakeDocker struct {
 	GetImageUserImage            string
 	GetImageUserResult           string
 	GetImageUserError            error
+	GetImageEntrypointResult     []string
+	GetImageEntrypointError      error
 	CommitContainerOpts          CommitContainerOptions
 	CommitContainerResult        string
 	CommitContainerError         error
@@ -135,6 +137,11 @@ func (f *FakeDocker) GetImageID(image string) (string, error) {
 func (f *FakeDocker) GetImageUser(image string) (string, error) {
 	f.GetImageUserImage = image
 	return f.GetImageUserResult, f.GetImageUserError
+}
+
+// GetImageEntrypoint returns an empty entrypoint
+func (f *FakeDocker) GetImageEntrypoint(image string) ([]string, error) {
+	return f.GetImageEntrypointResult, f.GetImageEntrypointError
 }
 
 // CommitContainer commits a fake Docker container

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -11,7 +11,11 @@ import (
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
-var glog = utilglog.StderrLog
+var (
+	// DefaultEntrypoint is the default entry point used when starting containers
+	DefaultEntrypoint = []string{"/bin/env"}
+	glog              = utilglog.StderrLog
+)
 
 // A DockerRunner allows running a Docker image as a new container, streaming
 // stdout and stderr with glog.
@@ -44,6 +48,7 @@ func (b *DockerRunner) Run(config *api.Config) error {
 
 	opts := docker.RunContainerOptions{
 		Image:        config.Tag,
+		Entrypoint:   DefaultEntrypoint,
 		Stdout:       outWriter,
 		Stderr:       errWriter,
 		TargetImage:  true,
@@ -51,7 +56,7 @@ func (b *DockerRunner) Run(config *api.Config) error {
 		CapDrop:      config.DropCapabilities,
 	}
 
-	//NOTE, we've seen some Golang level deadlock issues with the streaming of cmd output to
+	// NOTE, we've seen some Golang level deadlock issues with the streaming of cmd output to
 	// glog, but part of the deadlock seems to have occurred when stdout was "silent"
 	// and produced no data, such as when we would do a git clone with the --quiet option.
 	// We have not seen the hang when the Cmd produces output to stdout.


### PR DESCRIPTION
fixes https://github.com/openshift/source-to-image/issues/475

this basically reimplements https://github.com/openshift/source-to-image/pull/476 but ensures the entrypoint in the final committed image is not changed to "env".
