### PR TITLE
Added checks for existing content is git repo

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -21,6 +21,8 @@ const (
 	STIContainerError
 	SourcePathError
 	UserNotAllowedError
+	MissingGitBinaryError
+	EmptyGitRepositoryError
 )
 
 // Error represents an error thrown during STI execution
@@ -230,5 +232,26 @@ func NewUserNotAllowedError(image string, onbuild bool) error {
 		Message:    msg,
 		ErrorCode:  UserNotAllowedError,
 		Suggestion: fmt.Sprintf("modify image %q to use a numeric user within the allowed range or build without the --allowed-uids flag", image),
+	}
+}
+
+// NewMissingGitBinaryError returns a new error that indicates that we couldn't
+// find a Git binary in the path.
+func NewMissingGitBinaryError() error {
+	return Error{
+		Message:    "Git was not found in the PATH",
+		ErrorCode:  MissingGitBinaryError,
+		Suggestion: "Install Git from your distribution's vendor, or use --copy to ignore the repository.",
+	}
+}
+
+// NewEmptyGitRepositoryError returns a new error which indicates that a found
+// .git directory has no tracking information, e.g. if the user simply used
+// `git init` and forgot about the repository
+func NewEmptyGitRepositoryError(source string) error {
+	return Error{
+		Message:    fmt.Sprintf("The git repository \"%s\" has no tracking information or commits", source),
+		ErrorCode:  EmptyGitRepositoryError,
+		Suggestion: "Either commit files to the Git repository, remove the .git directory from the project, or use --copy to ignore the repository.",
 	}
 }

--- a/pkg/scm/git/clone.go
+++ b/pkg/scm/git/clone.go
@@ -23,7 +23,12 @@ func (c *Clone) Download(config *api.Config) (*api.SourceInfo, error) {
 	hasRef := len(config.Ref) > 0
 	cloneConfig := api.CloneConfig{Quiet: true, Recursive: !config.IgnoreSubmodules && !hasRef}
 
-	if c.ValidCloneSpec(config.Source) {
+	ok, err := c.ValidCloneSpec(config.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
 		if len(config.ContextDir) > 0 {
 			targetSourceDir = filepath.Join(config.WorkingDir, api.ContextTmp)
 			glog.V(1).Infof("Downloading %q (%q) ...", config.Source, config.ContextDir)

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -14,7 +14,11 @@ func createLocalGitDirectory(t *testing.T) string {
 	if err != nil {
 		t.Error(err)
 	}
-	os.Mkdir(filepath.Join(dir, ".git"), 0600)
+	os.MkdirAll(filepath.Join(dir, ".git/refs/heads"), 0777)
+	os.MkdirAll(filepath.Join(dir, ".git/refs/remotes"), 0777)
+	os.MkdirAll(filepath.Join(dir, ".git/branches"), 0777)
+	os.MkdirAll(filepath.Join(dir, ".git/objects/foo"), 0777)
+	os.Create(filepath.Join(dir, ".git/objects/foo") + "bar")
 	return dir
 }
 

--- a/pkg/test/git.go
+++ b/pkg/test/git.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/openshift/source-to-image/pkg/api"
 	"net/url"
+
+	"github.com/openshift/source-to-image/pkg/api"
 )
 
 // FakeGit provides a fake Git
@@ -28,9 +29,9 @@ type FakeGit struct {
 }
 
 // ValidCloneSpec returns a valid Git clone specification
-func (f *FakeGit) ValidCloneSpec(source string) bool {
+func (f *FakeGit) ValidCloneSpec(source string) (bool, error) {
 	f.ValidCloneSpecSource = source
-	return f.ValidCloneSpecResult
+	return f.ValidCloneSpecResult, nil
 }
 
 //ValidCloneSpecRemoteOnly returns a valid Git clone specification


### PR DESCRIPTION
This fixes an error when the git repo is empty, e.g. the user only ran
`git init`.  If the repo is empty, we use system copy commands instead
of git commands, and warn the user.

Also added warnings for if there is a .git directory in the project, but
a Git binary is not installed.

Currently working on tests, just posting this for discussion
@bparees 

Old output, git installed:
```

---> Installing application source ...
ERROR: cp: cannot stat '/tmp/src/.': No such file or directory

ERROR: An error occurred: non-zero (13) exit code from openshift/ruby-22-centos7
```

Old output, git not installed:
```

---> Installing application source ...
---> Building your Ruby application from source ...
WARNING: Rubygem Rack is not installed in the present image.
Add rack to your Gemfile in order to start the web server.

```

New output, git installed:
```
Warning: file:///home/rymurphy/documents/projects/go/src/github.com/openshift/source-to-image/asdf is a Git repository, but is empty.

---> Installing application source ...
---> Building your Ruby application from source ...
WARNING: Rubygem Rack is not installed in the present image.
Add rack to your Gemfile in order to start the web server.

```

New output, git not installed
```
Warning: file:///home/rymurphy/documents/projects/go/src/github.com/openshift/source-to-image/asdf is a Git repository, but you do not have git installed.
Warning: file:///home/rymurphy/documents/projects/go/src/github.com/openshift/source-to-image/asdf is a Git repository, but is empty.

---> Installing application source ...
---> Building your Ruby application from source ...
WARNING: Rubygem Rack is not installed in the present image.
Add rack to your Gemfile in order to start the web server.

```
Fixes #298 