### PR TITLE
Fixing s2i dir truncate error

### DIFF
--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -48,9 +48,37 @@ func ExpandInjectedFiles(injections api.VolumeList) ([]string, error) {
 			if err != nil {
 				return err
 			}
+
+			// Detected files will be truncated. k8s' AtomicWriter creates
+			// directories and symlinks to directories in order to inject files.
+			// An attempt to truncate either a dir or symlink to a dir will fail.
+			// Thus, we need to dereference symlinks to see if they might point
+			// to a directory.
+			// Do not try to simplify this logic to simply return nil if a symlink
+			// is detected. During the tar transfer to an assemble image, symlinked
+			// files are turned concrete (i.e. they will be turned into regular files
+			// containing the content of their target). These newly concrete files
+			// need to be truncated as well.
+
+			if f.Mode()&os.ModeSymlink != 0 {
+				linkDest, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return fmt.Errorf("Unable to evaluate symlink [%v]: %v", path, err)
+				}
+				// Evaluate the destination of the link.
+				f, err = os.Lstat(linkDest)
+				if err != nil {
+					// This is not a fatal error. If AtomicWrite tried multiple times, a symlink might not point
+					// to a valid destination.
+					glog.Warningf("Unable to lstat symlink destination [%v]->[%v]. Partial atomic write?", path, linkDest, err)
+					return nil
+				}
+			}
+
 			if f.IsDir() {
 				return nil
 			}
+
 			newPath := filepath.Join(s.Destination, strings.TrimPrefix(path, s.Source))
 			result = append(result, newPath)
 			return nil


### PR DESCRIPTION
Running origin's test/extended/builds/secrets.go, I was receiving a consistent error on the source buildconfig with secrets.  
The build would always fail at this point:
```
...
I0721 19:15:25.305187       1 tar.go:263] Adding to tar: /tmp/s2i-build790441331/upload/src/Gemfile as src/Gemfile
I0721 19:15:25.305238       1 tar.go:263] Adding to tar: /tmp/s2i-build790441331/upload/src/config.ru as src/config.ru
E0721 19:15:25.546017       1 util.go:96] truncate: cannot open '/tmp/..data' for writing: Is a directory
```

Peering into the builder container, this ..data path is a **symlink** to a directory. In go, os.IsDir(symlinkFileInfo) == false even if it points to a directory. The existing check in ExpandInjectedFiles(api.VolumeList) for IsDir() returned false, allowing the build process to add a "truncate -s0 ..../..data" to the removal script.

Secrets are presently injected with k8s atomic_writer.go:AtomicWriter.Write . This method creates multiple directories and symlinks to ensure atomicity. Injecting three secret files, for example, will create:
```
/var/run/secrets/openshift.io/build/testsecret2
/var/run/secrets/openshift.io/build/testsecret2/..data
/var/run/secrets/openshift.io/build/testsecret2/secret3
/var/run/secrets/openshift.io/build/testsecret2/secret2
/var/run/secrets/openshift.io/build/testsecret2/secret1
/var/run/secrets/openshift.io/build/testsecret2/..7987_22_07_13_40_33.231933614
/var/run/secrets/openshift.io/build/testsecret2/..7987_22_07_13_40_33.231933614/secret3
/var/run/secrets/openshift.io/build/testsecret2/..7987_22_07_13_40_33.231933614/secret2
/var/run/secrets/openshift.io/build/testsecret2/..7987_22_07_13_40_33.231933614/secret1
```
With the following symlinks:
```
lrwxrwxrwx 1 root root 14 Jul 22 17:40 secret1 -> ..data/secret1
lrwxrwxrwx 1 root root 14 Jul 22 17:40 secret2 -> ..data/secret2
lrwxrwxrwx 1 root root 14 Jul 22 17:40 secret3 -> ..data/secret3
sh-4.2# ls -l ..data
lrwxrwxrwx 1 root root 31 Jul 22 17:40 ..data -> ..7987_22_07_13_40_33.231933614
```
Only the files in ..7987_22_07_13_40_33.231933614 are concrete. 

I believe this was introduced with a new version of k8s. Older versions of k8s.io/kubernetes/pkg/volume/secret/secrets.go   do not use the AtomicWriter to transfer secrets.