### PR TITLE
Fixing permission issue during rm_injections

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -196,8 +196,8 @@ func (t *stiTar) StreamFileAsTarWithCallback(source, name string, writer io.Writ
 	if err := fs.Copy(source, dst); err != nil {
 		return err
 	}
-	fileInfo, fileErr := os.Stat(source)
-	if err := walkFn(source, fileInfo, fileErr); err != nil {
+	fileInfo, fileErr := os.Stat(dst)
+	if err := walkFn(dst, fileInfo, fileErr); err != nil {
 		return err
 	}
 	return t.CreateTarStream(tmpDir, false, writer)


### PR DESCRIPTION
Post bump, this should fix origin 10009. 
StreamFileAsTar makes an attempt to chmod the rm-injections script to 666 before injecting it with a tar stream, but StreamFileAsTarWithCallback was actually setting these permissions on the primordial source for rm-injections. 

Before this PR, rm-injections ended up as root:root 600 in the build container. Now it should be 666 and source-able by the default user.