### PR TITLE
log stderr as info messages

### DIFF
--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -325,7 +325,7 @@ func (step *startRuntimeImageAndUploadFilesStep) execute(ctx *postExecutorStepCo
 	go dockerpkg.StreamContainerIO(outReader, nil, glog.V(0).Info)
 
 	errOutput := ""
-	go dockerpkg.StreamContainerIO(errReader, &errOutput, glog.Error)
+	go dockerpkg.StreamContainerIO(errReader, &errOutput, glog.Info)
 
 	// switch to the next stage of post executors steps
 	step.builder.postExecutorStage++

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -428,7 +428,7 @@ func (builder *STI) Save(config *api.Config) (err error) {
 		CapDrop:         config.DropCapabilities,
 	}
 
-	go dockerpkg.StreamContainerIO(errReader, nil, glog.Error)
+	go dockerpkg.StreamContainerIO(errReader, nil, glog.Info)
 	err = builder.docker.RunContainer(opts)
 	if e, ok := err.(errors.ContainerError); ok {
 		return errors.NewSaveArtifactsError(image, e.Output, err)
@@ -584,7 +584,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 
 	}(outReader)
 
-	go dockerpkg.StreamContainerIO(errReader, &errOutput, glog.Error)
+	go dockerpkg.StreamContainerIO(errReader, &errOutput, glog.Info)
 
 	err := builder.docker.RunContainer(opts)
 	if util.IsTimeoutError(err) {


### PR DESCRIPTION
@php-coder ptal, the current output looks horrible because npm (among other things) uses stderr for its output, so you end up with `ERROR: some normal npm operation` in your normal s2i output.

this seems like the lesser of two evils to me right now.
