### PR TITLE
Use runtime authentication in installer

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -120,12 +120,18 @@ func New(config *api.Config, overrides build.Overrides) (*STI, error) {
 	}
 
 	if len(config.RuntimeImage) > 0 {
-		builder.runtimeInstaller = scripts.NewInstaller(config.RuntimeImage, config.ScriptsURL, config.ScriptDownloadProxyConfig, docker, config.PullAuthentication)
-
 		builder.runtimeDocker, err = dockerpkg.New(config.DockerConfig, config.RuntimeAuthentication)
 		if err != nil {
 			return builder, err
 		}
+
+		builder.runtimeInstaller = scripts.NewInstaller(
+			config.RuntimeImage,
+			config.ScriptsURL,
+			config.ScriptDownloadProxyConfig,
+			builder.runtimeDocker,
+			config.RuntimeAuthentication,
+		)
 	}
 
 	// The sources are downloaded using the Git downloader.


### PR DESCRIPTION
Before this change S2I failed to inspect runtime image (when we're invoked from OpenShift and tried to do extended build with the scripts inside of runtime image):
>I0808 09:39:54.899522       1 docker.go:459] error inspecting image 172.30.253.131:5000/extended-test-extended-build-1ecb2-ry755/jvm-runner-with-scripts@sha256:f4a82128571de55bb2a4ad30a13e87a9caf75aa134e00cf8eb7e67e17384f425: no such image
>I0808 09:39:54.899631       1 docker.go:446] Image "172.30.253.131:5000/extended-test-extended-build-1ecb2-ry755/jvm-runner-with-scripts@sha256:f4a82128571..." not available locally, pulling ...
>I0808 09:39:54.900948       1 docker.go:468] Pulling Docker image 172.30.253.131:5000/extended-test-extended-build-1ecb2-ry755/jvm-runner-with-scripts@sha256:f4a82128571de55bb2a4ad30a13e87a9caf75aa134e00cf8eb7e67e17384f425 ...
>I0808 09:39:54.921495       1 docker.go:471] An error was received from the PullImage call: unauthorized: authentication required

And because of this error S2I shown wrong messages:

>W0808 09:39:57.127676       1 sti.go:314] Error getting assemble-runtime from : script "assemble-runtime" not installed

But build was succeed. I'm not sure that something was really broken but at least these messages confused me.

PTAL @bparees