### PR TITLE
Removed pkg/test from excluded packages in script

### DIFF
--- a/hack/rebase-to-origin.sh
+++ b/hack/rebase-to-origin.sh
@@ -28,7 +28,6 @@ readonly exclude_pkgs=(
   pkg/create
   pkg/docker/test
   pkg/run
-  pkg/test
   pkg/version
 )
 


### PR DESCRIPTION
This allows us to use Git testing utilities in origin.

Perhaps in the future we should merge the Git utilities that are spread between the projects?

Sorry for the quick one-liners :)