### PR TITLE
s2i: unexpected error entry in s2i build logs

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -575,7 +575,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 				// we're ignoring ErrClosedPipe, as this is information
 				// the docker container ended streaming logs
 				if glog.Is(2) && err != io.ErrClosedPipe && err != io.EOF {
-					glog.Errorf("Error reading docker stdout, %v", err)
+					glog.Errorf("Error reading docker stdout, %#v", err)
 				}
 				break
 			}


### PR DESCRIPTION
Bug 1364965
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1364965
Detailed explanation when gathering build output, the intent is to
ignore expect "errors" like EOF, but an EOF error showed up in the logs;
we could not decipher actual type besides io.EOF that arrived, but we augmented
to log to print the type; next time it arrives, we can add that type to the check list

@bparees PTAL