### PR TITLE
Change file exists check to any error returned by os.Stat

### DIFF
--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -416,7 +416,7 @@ func isValidGitRepository(dir string) (bool, error) {
 // doesExist checks if the path exists, removing file:// if needed for OS FS check
 func doesExist(dir string) bool {
 	_, err := os.Stat(strings.TrimPrefix(dir, "file://"))
-	return !(err != nil && os.IsNotExist(err))
+	return err == nil
 }
 
 // hasGitBinary checks if the 'git' binary is available on the system


### PR DESCRIPTION
When a ssh url is passed to os.Stat in Windows, the error returned is something other than  ErrNotExist, which results in an error when 'oc new-app' is called with a git url in Windows.

With this change, any error returned by os.Stat will result in us assuming the file doesn't exist.