### PR TITLE
Additional build information

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -150,7 +150,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 				glog.Fatalf("Unable to connect to Docker daemon. Please set the DOCKER_HOST or make sure the Docker socket %q exists", cfg.DockerConfig.Endpoint)
 			}
 
-			builder, err := strategies.GetStrategy(cfg)
+			builder, _, err := strategies.GetStrategy(cfg)
 			checkErr(err)
 			result, err := builder.Build(cfg)
 			checkErr(err)
@@ -241,7 +241,7 @@ func newCmdRebuild(cfg *api.Config) *cobra.Command {
 
 			glog.V(2).Infof("\n%s\n", describe.DescribeConfig(cfg))
 
-			builder, err := strategies.GetStrategy(cfg)
+			builder, _, err := strategies.GetStrategy(cfg)
 			checkErr(err)
 			result, err := builder.Build(cfg)
 			checkErr(err)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -325,7 +325,85 @@ type Result struct {
 
 	// ImageID describes resulting image ID.
 	ImageID string
+
+	// BuildInfo holds information about the result of a build.
+	BuildInfo BuildInfo
 }
+
+// BuildInfo holds information about a particular step in the build process.
+type BuildInfo struct {
+	// FailureReason is a camel case reason that is used by the machine to reply
+	// back to the OpenShift builder with information why any of the steps in the
+	// build, failed.
+	FailureReason StepFailureReason
+}
+
+// StepFailureReason holds the type of failure that occured during the build
+// process.
+type StepFailureReason string
+
+const (
+	// ReasonAssembleFailed is the reason associated with the Assemble script
+	// failing.
+	ReasonAssembleFailed StepFailureReason = "AssembleFailed"
+
+	// ReasonPullBuilderImageFailed is the reason associated with failing to pull
+	// the builder image.
+	ReasonPullBuilderImageFailed StepFailureReason = "PullBuilderImageFailed"
+
+	// ReasonPullRuntimeImageFailed is the reason associated with failing to pull
+	// the runtime image.
+	ReasonPullRuntimeImageFailed StepFailureReason = "PullRuntimeImageFailed"
+
+	// ReasonCommitContainerFailed is the reason associated with failing to
+	// commit the container to the final image.
+	ReasonCommitContainerFailed StepFailureReason = "ContainerCommitFailed"
+
+	// ReasonFetchSourceFailed is the reason associated with failing to download
+	// the source of the build.
+	ReasonFetchSourceFailed StepFailureReason = "FetchSourceFailed"
+
+	// ReasonDockerImageBuildFailed is the reasons associated with a failed
+	// Docker image build.
+	ReasonDockerImageBuildFailed StepFailureReason = "DockerImageBuildFailed"
+
+	// ReasonDockerFileCreateFailed is the reason associated with failing to create a
+	// Dockerfile for a build.
+	ReasonDockerFileCreateFailed StepFailureReason = "DockerFileCreationFailed"
+
+	// ReasonInvalidArtifactsMapping is the reason associated with an
+	// invalid artifacts mapping of files that need to be copied.
+	ReasonInvalidArtifactsMapping StepFailureReason = "InvalidArtifactsMapping"
+
+	// ReasonArtifactsFetchFailed is the reason associated with a failure to
+	// download specified scripts in the application image.
+	ReasonArtifactsFetchFailed StepFailureReason = "FetchScriptsFailed"
+
+	// ReasonFSOperationFailed is the reason associated with a failed fs
+	// operation. Create, remove directory, copy file, etc.
+	ReasonFSOperationFailed StepFailureReason = "FileSystemOperationFailed"
+
+	// ReasonInstallScriptsFailed is the reason associated with a failure to
+	// install scripts in the builder image.
+	ReasonInstallScriptsFailed StepFailureReason = "InstallScriptsFailed"
+
+	// ReasonGenericS2IBuildFailed is the reason associated with a broad range of
+	// failure.
+	ReasonGenericS2IBuildFailed StepFailureReason = "GenericS2IBuildFailed"
+
+	// ReasonUnmetS2IDependencies is the failure reason associated with a
+	// builder image that doesn't contain required dependencies for building the
+	// app.
+	ReasonUnmetS2IDependencies StepFailureReason = "UnmetBuilderImageDependencies"
+
+	// ReasonTarSourceFailed is the failurea reason associated with a failure to
+	// tar the current source.
+	ReasonTarSourceFailed StepFailureReason = "TarSourceFailed"
+
+	// ReasonOnBuildForbidden is the failure reason associated with an image that
+	// uses the ONBUILD instruction when it's not allowed.
+	ReasonOnBuildForbidden StepFailureReason = "OnBuildForbidden"
+)
 
 // InstallResult structure describes the result of install operation
 type InstallResult struct {

--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -55,9 +55,10 @@ func (step *storePreviousImageStep) execute(ctx *postExecutorStepContext) error 
 	if step.builder.incremental && step.builder.config.RemovePreviousImage {
 		glog.V(3).Info("Executing step: store previous image")
 		ctx.previousImageID = step.getPreviousImage()
-	} else {
-		glog.V(3).Info("Skipping step: store previous image")
+		return nil
 	}
+
+	glog.V(3).Info("Skipping step: store previous image")
 	return nil
 }
 
@@ -79,9 +80,10 @@ func (step *removePreviousImageStep) execute(ctx *postExecutorStepContext) error
 	if step.builder.incremental && step.builder.config.RemovePreviousImage {
 		glog.V(3).Info("Executing step: remove previous image")
 		step.removePreviousImage(ctx.previousImageID)
-	} else {
-		glog.V(3).Info("Skipping step: remove previous image")
+		return nil
 	}
+
+	glog.V(3).Info("Skipping step: remove previous image")
 	return nil
 }
 
@@ -128,6 +130,7 @@ func (step *commitImageStep) execute(ctx *postExecutorStepContext) error {
 
 	ctx.imageID, err = commitContainer(step.docker, ctx.containerID, cmd, user, step.builder.config.Tag, step.builder.env, entrypoint, ctx.labels)
 	if err != nil {
+		step.builder.result.BuildInfo.FailureReason = api.ReasonCommitContainerFailed
 		return err
 	}
 
@@ -383,10 +386,10 @@ func (step *invokeCallbackStep) execute(ctx *postExecutorStepContext) error {
 		glog.V(3).Info("Executing step: invoke callback url")
 		step.builder.result.Messages = step.callbackInvoker.ExecuteCallback(step.builder.config.CallbackURL,
 			step.builder.result.Success, ctx.labels, step.builder.result.Messages)
-	} else {
-		glog.V(3).Info("Skipping step: invoke callback url")
+		return nil
 	}
 
+	glog.V(3).Info("Skipping step: invoke callback url")
 	return nil
 }
 

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -119,7 +119,7 @@ func New(config *api.Config, overrides build.Overrides) (*STI, error) {
 	if len(config.RuntimeImage) > 0 {
 		builder.runtimeDocker, err = dockerpkg.New(config.DockerConfig, config.RuntimeAuthentication)
 		if err != nil {
-			return builder, err
+			return nil, err
 		}
 
 		builder.runtimeInstaller = scripts.NewInstaller(
@@ -145,18 +145,20 @@ func New(config *api.Config, overrides build.Overrides) (*STI, error) {
 		builder.source = downloader
 		config.Source = sourceURL
 	}
-
 	builder.garbage = build.NewDefaultCleaner(builder.fs, builder.docker)
 	builder.layered, err = layered.New(config, builder, overrides)
 
+	if err != nil {
+		return nil, err
+	}
+
 	// Set interfaces
 	builder.preparer = builder
-	// later on, if we support say .gitignore func in addition to .dockerignore func, setting
-	// ignorer will be based on config setting
+	// later on, if we support say .gitignore func in addition to .dockerignore
+	// func, setting ignorer will be based on config setting
 	builder.ignorer = &ignore.DockerIgnorer{}
 	builder.artifacts = builder
 	builder.scripts = builder
-
 	builder.postExecutor = builder
 	builder.initPostExecutorSteps()
 
@@ -168,11 +170,14 @@ func New(config *api.Config, overrides build.Overrides) (*STI, error) {
 // of the build itself.  Callers should check the Success field of the result
 // to determine whether a build succeeded or not.
 func (builder *STI) Build(config *api.Config) (*api.Result, error) {
+	builder.result = &api.Result{}
+
 	defer builder.garbage.Cleanup(config)
 
 	glog.V(1).Infof("Preparing to build %s", config.Tag)
+	// The failure reason is updated inside the Prepare function.
 	if err := builder.preparer.Prepare(config); err != nil {
-		return nil, err
+		return builder.result, err
 	}
 
 	if builder.incremental = builder.artifacts.Exists(config); builder.incremental {
@@ -196,17 +201,21 @@ func (builder *STI) Build(config *api.Config) (*api.Result, error) {
 		glog.V(1).Infof("Running %q in %q", api.Assemble, config.Tag)
 	}
 	if err := builder.scripts.Execute(api.Assemble, config.AssembleUser, config); err != nil {
+		builder.result.BuildInfo.FailureReason = api.ReasonAssembleFailed
+
 		switch e := err.(type) {
 		case errors.ContainerError:
 			if !isMissingRequirements(e.Output) {
-				return nil, err
+				builder.result.BuildInfo.FailureReason = api.ReasonUnmetS2IDependencies
+				return builder.result, err
 			}
 			glog.V(1).Info("Image is missing basic requirements (sh or tar), layered build will be performed")
 			return builder.layered.Build(config)
 		default:
-			return nil, err
+			return builder.result, err
 		}
 	}
+	builder.result.Success = true
 
 	return builder.result, nil
 }
@@ -216,19 +225,22 @@ func (builder *STI) Build(config *api.Config) (*api.Result, error) {
 // struct Build func leverages the STI struct Prepare func directly below.
 func (builder *STI) Prepare(config *api.Config) error {
 	var err error
+	if builder.result == nil {
+		builder.result = &api.Result{}
+	}
+
 	if len(config.WorkingDir) == 0 {
 		if config.WorkingDir, err = builder.fs.CreateWorkingDirectory(); err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonFSOperationFailed
 			return err
 		}
 	}
 
-	builder.result = &api.Result{
-		Success:    false,
-		WorkingDir: config.WorkingDir,
-	}
+	builder.result.WorkingDir = config.WorkingDir
 
 	if len(config.RuntimeImage) > 0 {
-		if err := dockerpkg.GetRuntimeImage(config, builder.runtimeDocker); err != nil {
+		if err = dockerpkg.GetRuntimeImage(config, builder.runtimeDocker); err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonPullRuntimeImageFailed
 			glog.Errorf("Unable to pull runtime image %q: %v", config.RuntimeImage, err)
 			return err
 		}
@@ -237,13 +249,16 @@ func (builder *STI) Prepare(config *api.Config) error {
 		if len(builder.config.RuntimeArtifacts) == 0 {
 			mapping, err := builder.docker.GetAssembleInputFiles(config.RuntimeImage)
 			if err != nil {
+				builder.result.BuildInfo.FailureReason = api.ReasonInvalidArtifactsMapping
 				return err
 			}
 			if len(mapping) == 0 {
+				builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 				return fmt.Errorf("No runtime artifacts to copy were specified")
 			}
 			for _, value := range strings.Split(mapping, ";") {
 				if err = builder.config.RuntimeArtifacts.Set(value); err != nil {
+					builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 					return fmt.Errorf("Couldn't parse %q label with value %q on image %q: %v",
 						dockerpkg.AssembleInputFilesLabel, mapping, config.RuntimeImage, err)
 				}
@@ -252,14 +267,21 @@ func (builder *STI) Prepare(config *api.Config) error {
 		// we're validating values here to be sure that we're handling both of the cases of the invocation:
 		// from main() and as a method from OpenShift
 		for _, volumeSpec := range builder.config.RuntimeArtifacts {
-			if !path.IsAbs(volumeSpec.Source) {
-				return fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: source must be an absolute path", volumeSpec.Source, volumeSpec.Destination)
+			var volumeErr error
+
+			switch {
+			case !path.IsAbs(volumeSpec.Source):
+				volumeErr = fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: source must be an absolute path", volumeSpec.Source, volumeSpec.Destination)
+			case path.IsAbs(volumeSpec.Destination):
+				volumeErr = fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: destination must be a relative path", volumeSpec.Source, volumeSpec.Destination)
+			case strings.HasPrefix(volumeSpec.Destination, ".."):
+				volumeErr = fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: destination cannot start with '..'", volumeSpec.Source, volumeSpec.Destination)
+			default:
+				continue
 			}
-			if path.IsAbs(volumeSpec.Destination) {
-				return fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: destination must be a relative path", volumeSpec.Source, volumeSpec.Destination)
-			}
-			if strings.HasPrefix(volumeSpec.Destination, "..") {
-				return fmt.Errorf("Invalid runtime artifacts mapping: %q -> %q: destination cannot start with '..'", volumeSpec.Source, volumeSpec.Destination)
+			if volumeErr != nil {
+				builder.result.BuildInfo.FailureReason = api.ReasonInvalidArtifactsMapping
+				return volumeErr
 			}
 		}
 	}
@@ -267,6 +289,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 	// Setup working directories
 	for _, v := range workingDirs {
 		if err = builder.fs.MkdirAll(filepath.Join(config.WorkingDir, v)); err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonFSOperationFailed
 			return err
 		}
 	}
@@ -274,6 +297,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 	// fetch sources, for their .s2i/bin might contain s2i scripts
 	if len(config.Source) > 0 {
 		if builder.sourceInfo, err = builder.source.Download(config); err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonFetchSourceFailed
 			return err
 		}
 	}
@@ -281,6 +305,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 	// get the scripts
 	required, err := builder.installer.InstallRequired(builder.requiredScripts, config.WorkingDir)
 	if err != nil {
+		builder.result.BuildInfo.FailureReason = api.ReasonInstallScriptsFailed
 		return err
 	}
 	optional := builder.installer.InstallOptional(builder.optionalScripts, config.WorkingDir)
@@ -289,9 +314,6 @@ func (builder *STI) Prepare(config *api.Config) error {
 
 	if len(config.RuntimeImage) > 0 && builder.runtimeInstaller != nil {
 		optionalRuntime := builder.runtimeInstaller.InstallOptional(builder.optionalRuntimeScripts, config.WorkingDir)
-		if err != nil {
-			return err
-		}
 		requiredAndOptional = append(requiredAndOptional, optionalRuntime...)
 	}
 
@@ -304,21 +326,24 @@ func (builder *STI) Prepare(config *api.Config) error {
 			}
 		}
 		if failedCount == len(requiredAndOptional) {
+			builder.result.BuildInfo.FailureReason = api.ReasonArtifactsFetchFailed
 			return fmt.Errorf("Could not download any scripts from URL %v", config.ScriptsURL)
 		}
 	}
 
 	for _, r := range requiredAndOptional {
-		if r.Error == nil {
-			builder.externalScripts[r.Script] = r.Downloaded
-			builder.installedScripts[r.Script] = r.Installed
-			builder.scriptsURL[r.Script] = r.URL
-		} else {
+		if r.Error != nil {
 			glog.Warningf("Error getting %v from %s: %v", r.Script, r.URL, r.Error)
+			continue
 		}
+
+		builder.externalScripts[r.Script] = r.Downloaded
+		builder.installedScripts[r.Script] = r.Installed
+		builder.scriptsURL[r.Script] = r.URL
 	}
 
-	// see if there is a .s2iignore file, and if so, read in the patterns an then search and delete on
+	// see if there is a .s2iignore file, and if so, read in the patterns an then
+	// search and delete on
 	return builder.ignorer.Ignore(config)
 }
 
@@ -386,7 +411,12 @@ func (builder *STI) Exists(config *api.Config) bool {
 // current build.
 func (builder *STI) Save(config *api.Config) (err error) {
 	artifactTmpDir := filepath.Join(config.WorkingDir, "upload", "artifacts")
+	if builder.result == nil {
+		builder.result = &api.Result{}
+	}
+
 	if err = builder.fs.Mkdir(artifactTmpDir); err != nil {
+		builder.result.BuildInfo.FailureReason = api.ReasonFSOperationFailed
 		return err
 	}
 
@@ -407,6 +437,7 @@ func (builder *STI) Save(config *api.Config) (err error) {
 	if len(user) == 0 {
 		user, err = builder.docker.GetImageUser(image)
 		if err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 			return err
 		}
 		glog.V(3).Infof("The assemble user is not set, defaulting to %q user", user)
@@ -433,11 +464,14 @@ func (builder *STI) Save(config *api.Config) (err error) {
 	go dockerpkg.StreamContainerIO(errReader, nil, func(a ...interface{}) { glog.Info(a...) })
 	err = builder.docker.RunContainer(opts)
 	if e, ok := err.(errors.ContainerError); ok {
-		// even with deferred close above, close errReader now so we avoid data race condition on errOutput;
-		// closing will cause StreamContainerIO to exit, thus releasing the writer in the equation
+		// even with deferred close above, close errReader now so we avoid data
+		// race condition on errOutput;
+		// closing will cause StreamContainerIO to exit, thus releasing the writer in
+		// the equation
 		errReader.Close()
-		return errors.NewSaveArtifactsError(image, e.Output, err)
+		err = errors.NewSaveArtifactsError(image, e.Output, err)
 	}
+	builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 	return err
 }
 
@@ -490,15 +524,18 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 	if len(config.Injections) > 0 && command == api.Assemble {
 		workdir, err := builder.docker.GetImageWorkdir(config.BuilderImage)
 		if err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 			return err
 		}
 		config.Injections = util.FixInjectionsWithRelativePath(workdir, config.Injections)
 		injectedFiles, err := util.ExpandInjectedFiles(config.Injections)
 		if err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonInstallScriptsFailed
 			return err
 		}
 		rmScript, err := util.CreateInjectedFilesRemovalScript(injectedFiles, "/tmp/rm-injections")
 		if err != nil {
+			builder.result.BuildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
 			return err
 		}
 		defer os.Remove(rmScript)

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -10,23 +10,38 @@ import (
 
 // GetStrategy decides what build strategy will be used for the STI build.
 // TODO: deprecated, use Strategy() instead
-func GetStrategy(config *api.Config) (build.Builder, error) {
+func GetStrategy(config *api.Config) (build.Builder, api.BuildInfo, error) {
 	return Strategy(config, build.Overrides{})
 }
 
 // Strategy creates the appropriate build strategy for the provided config, using
 // the overrides provided. Not all strategies support all overrides.
-func Strategy(config *api.Config, overrides build.Overrides) (build.Builder, error) {
+func Strategy(config *api.Config, overrides build.Overrides) (build.Builder, api.BuildInfo, error) {
+	var builder build.Builder
+	var buildInfo api.BuildInfo
+
 	image, err := docker.GetBuilderImage(config)
 	if err != nil {
-		return nil, err
+		buildInfo.FailureReason = api.ReasonPullBuilderImageFailed
+		return nil, buildInfo, err
 	}
 	config.HasOnBuild = image.OnBuild
 
 	// if we're blocking onbuild, just do a normal s2i build flow
 	// which won't do a docker build and invoke the onbuild commands
 	if image.OnBuild && !config.BlockOnBuild {
-		return onbuild.New(config, overrides)
+		builder, err = onbuild.New(config, overrides)
+		if err != nil {
+			buildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
+			return nil, buildInfo, err
+		}
+		return builder, buildInfo, nil
 	}
-	return sti.New(config, overrides)
+
+	builder, err = sti.New(config, overrides)
+	if err != nil {
+		buildInfo.FailureReason = api.ReasonGenericS2IBuildFailed
+		return nil, buildInfo, err
+	}
+	return builder, buildInfo, err
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -293,7 +293,7 @@ func (i *integrationTest) exerciseCleanAllowedUIDsBuild(tag, imageName string, e
 		ScriptsURL:        "",
 	}
 	config.AllowedUIDs.Set("1-")
-	_, err := strategies.GetStrategy(config)
+	_, _, err := strategies.GetStrategy(config)
 	if err != nil && !expectError {
 		t.Fatalf("Cannot create a new builder: %v", err)
 	}
@@ -349,7 +349,7 @@ func (i *integrationTest) exerciseCleanBuild(tag string, verifyCallback bool, im
 		CallbackURL:       callbackURL,
 		ScriptsURL:        scriptsURL}
 
-	b, err := strategies.GetStrategy(config)
+	b, _, err := strategies.GetStrategy(config)
 	if err != nil {
 		t.Fatalf("Cannot create a new builder.")
 	}
@@ -432,7 +432,7 @@ func (i *integrationTest) exerciseInjectionBuild(tag, imageName string, injectio
 		Tag:               tag,
 		Injections:        injectionList,
 	}
-	builder, err := strategies.GetStrategy(config)
+	builder, _, err := strategies.GetStrategy(config)
 	if err != nil {
 		t.Fatalf("Unable to create builder: %v", err)
 	}
@@ -475,7 +475,7 @@ func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, remove
 		RemovePreviousImage: removePreviousImage,
 	}
 
-	builder, err := strategies.GetStrategy(config)
+	builder, _, err := strategies.GetStrategy(config)
 	if err != nil {
 		t.Fatalf("Unable to create builder: %v", err)
 	}
@@ -499,7 +499,7 @@ func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, remove
 		PreviousImagePullPolicy: api.PullIfNotPresent,
 	}
 
-	builder, err = strategies.GetStrategy(config)
+	builder, _, err = strategies.GetStrategy(config)
 	if err != nil {
 		t.Fatalf("Unable to create incremental builder: %v", err)
 	}


### PR DESCRIPTION
This PR adds additional build information so that S2I can tell OpenShift a couple of things:
Why did the build fail. (besides fetch source, [which is implemented on the OpenShift side], container commit, builder image pull, runtime image pull, assemble runtime failed, assemble failed, etc. )

It's related to: https://github.com/openshift/origin/pull/10817