### PR TITLE
Add gitignore on create

### DIFF
--- a/pkg/create/create.go
+++ b/pkg/create/create.go
@@ -42,6 +42,7 @@ func (b *Bootstrap) AddTests() {
 	os.MkdirAll(b.DestinationDir+"/"+"test/test-app", 0700)
 	b.process(templates.TestRunScript, "test/run", 0700)
 	b.process(templates.Makefile, "Makefile", 0600)
+	b.process(templates.Gitignore, "test/.gitignore", 0644)
 }
 
 func (b *Bootstrap) process(t string, dst string, perm os.FileMode) {

--- a/pkg/create/templates/test.go
+++ b/pkg/create/templates/test.go
@@ -167,3 +167,6 @@ test:
 	docker build -t $(IMAGE_NAME)-candidate .
 	IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
 `
+
+const Gitignore = `.git/
+`


### PR DESCRIPTION
The build script neds a `git` repository, so the test script run [`git init`](https://github.com/luiscoms/source-to-image/blob/master/pkg/create/templates/test.go#L60)
But when an error occurs on build the script does not clean the `.git/` folder correctly.
To avoid git errors I just add a `.gitignore` file on test folder.