### PR TITLE
Replace wrong failure reason for assemble failed

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -202,12 +202,11 @@ func (builder *STI) Build(config *api.Config) (*api.Result, error) {
 		glog.V(1).Infof("Running %q in %q", api.Assemble, config.Tag)
 	}
 	if err := builder.scripts.Execute(api.Assemble, config.AssembleUser, config); err != nil {
-		builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(utilstatus.ReasonAssembleFailed, utilstatus.ReasonMessageAssembleFailed)
 
 		switch e := err.(type) {
 		case errors.ContainerError:
 			if !isMissingRequirements(e.Output) {
-				builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(utilstatus.ReasonUnmetS2IDependencies, utilstatus.ReasonMessageUnmetS2IDependencies)
+				builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(utilstatus.ReasonAssembleFailed, utilstatus.ReasonMessageAssembleFailed)
 				return builder.result, err
 			}
 			glog.V(1).Info("Image is missing basic requirements (sh or tar), layered build will be performed")

--- a/pkg/util/status/build_status.go
+++ b/pkg/util/status/build_status.go
@@ -83,20 +83,11 @@ const (
 	ReasonMessageInstallScriptsFailed api.StepFailureMessage = "Failed to install specified scripts"
 
 	// ReasonGenericS2IBuildFailed is the reason associated with a broad range of
-	// failure.
+	// failures.
 	ReasonGenericS2IBuildFailed api.StepFailureReason = "GenericS2IBuildFailed"
-	// ReasonMessageGenericS2iBuildFailed is the message with a broad range of
-	// failure.
+	// ReasonMessageGenericS2iBuildFailed is the message associated with a broad
+	// range of failures.
 	ReasonMessageGenericS2iBuildFailed api.StepFailureMessage = "Generic S2I Build failure - check S2I logs for details"
-
-	// ReasonUnmetS2IDependencies is the failure reason associated with a
-	// builder image that doesn't contain required dependencies for building the
-	// app.
-	ReasonUnmetS2IDependencies api.StepFailureReason = "UnmetBuilderImageDependencies"
-	// ReasonMessageUnmetS2IDependencies is the message associated with a
-	// builder image that doesn't contain required dependencies for building the
-	// app.
-	ReasonMessageUnmetS2IDependencies api.StepFailureMessage = "Builder image is missing mandatory dependencies (sh and tar)"
 
 	// ReasonTarSourceFailed is the failure reason associated with a failure to
 	// tar the current source.


### PR DESCRIPTION
i've confused !isMissing with isMissing, so the failure reason for this should just be a generic one.
We also don't fail for missing dependencies, but we continue the build with the layered build strategy.

