### PR TITLE
Remove invalid build constraint

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,4 +1,4 @@
-// +build integration,!no-docker
+// +build integration
 
 package integration
 


### PR DESCRIPTION
As fas as the git history can tell, the constraint was never referenced
by any script, never used.

```
$ go vet test/integration/integration_test.go
test/integration/integration_test.go:1: invalid non-alphanumeric build
constraint: integration,!no-docker
```