### PR TITLE
Fix hang in s2i strategy by avoiding wait on an error

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -640,12 +640,14 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 		errReader.Close()
 		return errors.NewContainerError(config.BuilderImage, e.ErrorCode, errOutput)
 	}
-	// Do not wait for source input if the container times out.
+	// Do not wait for source input if there was an error running the container
 	// FIXME: this potentially leaks a goroutine.
-	if !util.IsTimeoutError(err) {
-		wg.Wait()
+	if err != nil {
+		return err
 	}
-	return err
+
+	wg.Wait()
+	return nil
 }
 
 func (builder *STI) initPostExecutorSteps() {

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -919,6 +919,17 @@ func TestExecuteOK(t *testing.T) {
 	}
 }
 
+func TestExecuteRunContainerError(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	fd := rh.docker.(*docker.FakeDocker)
+	runContainerError := fmt.Errorf("an error")
+	fd.RunContainerError = runContainerError
+	err := rh.Execute("test-command", "", rh.config)
+	if err != runContainerError {
+		t.Errorf("Did not get expected error, got %v", err)
+	}
+}
+
 func TestExecuteErrorCreateTarFile(t *testing.T) {
 	rh := newFakeSTI(&FakeSTI{})
 	rh.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1390749
If an error occurs in RunContainer that is not a timeout error or a container error, then we wait indefinitely instead of returning an error.

I was able to easily reproduce the hang by simulating errors at different points in RunContainer. I also didn't see a case where a non-nil error should result in us still waiting for the WaitGroup to be done.