### PR TITLE
Corrected save-artifacts example to prevent tar stream corruption.

### DIFF
--- a/docs/builder_image.md
+++ b/docs/builder_image.md
@@ -123,12 +123,14 @@ The `save-artifacts` script is responsible for gathering all the dependencies in
 ```
 #!/bin/bash
 
-pushd ${HOME}
+# Besides the tar command, all other output to standard out must 
+# be surpressed.  Otherwise, the tar stream will be corrupted.
+pushd ${HOME} >/dev/null
 if [ -d deps ]; then
     # all deps contents to tar stream
     tar cf - deps
 fi
-popd
+popd >/dev/null
 
 ```
 


### PR DESCRIPTION
The pushd and popd commands in the example for save-artifacts example emit output to standard out.  This will corrupt the tar stream, and prevent the reuse of the saved artifacts.