### PR TITLE
Goroutine leak, logging and pkg doc

### DIFF
--- a/pkg/docker/doc.go
+++ b/pkg/docker/doc.go
@@ -1,4 +1,3 @@
-// Contains higher-level Docker operations needed by the S2I builder and executor
-// It uses go-dockerclient to communicate with Docker
-
+// Package docker implements Docker operations used by the S2I builder and
+// executor.
 package docker

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -833,7 +833,7 @@ func (d *stiDocker) redirectResponseToOutputStream(tty bool, outputStream, error
 // open the HijackedResponse until all of this is done.  Caller's responsibility
 // to close resp, as well as outputStream and errorStream if appropriate.
 func (d *stiDocker) holdHijackedConnection(tty bool, inputStream io.Reader, outputStream, errorStream io.WriteCloser, resp dockertypes.HijackedResponse) error {
-	receiveStdout := make(chan error)
+	receiveStdout := make(chan error, 1)
 	if outputStream != nil || errorStream != nil {
 		go func() {
 			receiveErr := d.redirectResponseToOutputStream(tty, outputStream, errorStream, resp.Reader)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -879,7 +879,6 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 			_, err = d.CheckAndPullImage(image)
 		}
 	}
-
 	if err != nil {
 		glog.V(0).Infof("error: Unable to get image metadata for %s: %v", image, err)
 		return err
@@ -916,13 +915,14 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) error {
 	}
 	createOpts.Config.Cmd = cmd
 
+	if createOpts.HostConfig != nil && createOpts.HostConfig.ShmSize <= 0 {
+		createOpts.HostConfig.ShmSize = DefaultShmSize
+	}
+
 	// Create a new container.
 	glog.V(2).Infof("Creating container with options {Name:%q Config:%+v HostConfig:%+v} ...", createOpts.Name, createOpts.Config, createOpts.HostConfig)
 	ctx, cancel := getDefaultContext()
 	defer cancel()
-	if createOpts.HostConfig != nil && createOpts.HostConfig.ShmSize <= 0 {
-		createOpts.HostConfig.ShmSize = DefaultShmSize
-	}
 	container, err := d.client.ContainerCreate(ctx, createOpts.Config, createOpts.HostConfig, createOpts.NetworkingConfig, createOpts.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
Miscellaneous improvements:

- Send on receiveStdout would block forever in goroutine when
holdHijackedConnection returns earlier.
- We should be updating createOpts.HostConfig.ShmSize before we log
createOpts.HostConfig.
- Pkg doc was outdated.