### PR TITLE
Prefer using https:// instead of git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a deep dive on S2I you can view [this presentation](https://www.youtube.com/
 
 Want to try it right now?  Download the [latest release](https://github.com/openshift/source-to-image/releases/latest) and run:
 
-	$ s2i build git://github.com/openshift/django-ex centos/python-35-centos7 hello-python
+	$ s2i build https://github.com/openshift/django-ex centos/python-35-centos7 hello-python
 	$ docker run -p 8080:8080 hello-python
 
 Now browse to http://localhost:8080 to see the running application.
@@ -228,12 +228,12 @@ You can start using `s2i` right away (see [releases](https://github.com/openshif
 with the following test sources and publicly available images:
 
 ```
-$ s2i build git://github.com/pmorie/simple-ruby openshift/ruby-20-centos7 test-ruby-app
+$ s2i build https://github.com/pmorie/simple-ruby openshift/ruby-20-centos7 test-ruby-app
 $ docker run --rm -i -p :8080 -t test-ruby-app
 ```
 
 ```
-$ s2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 test-jee-app
+$ s2i build https://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 test-jee-app
 $ docker run --rm -i -p :8080 -t test-jee-app
 ```
 

--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -58,8 +58,8 @@ func newCmdBuild(cfg *api.Config) *cobra.Command {
 		Short: "Build a new image",
 		Long:  "Build a new Docker image named <tag> (if provided) from a source repository and base image.",
 		Example: `
-# Build an application Docker image from a Git repository
-$ s2i build git://github.com/openshift/ruby-hello-world centos/ruby-22-centos7 hello-world-app
+# Build a Docker image from a remote Git repository
+$ s2i build https://github.com/openshift/ruby-hello-world centos/ruby-22-centos7 hello-world-app
 
 # Build from a local directory
 $ s2i build . centos/ruby-22-centos7 hello-world-app

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,7 +150,7 @@ Build a Ruby application from a Git source, using the official `ruby-20-centos7`
 image, the resulting image will be named `ruby-app`:
 
 ```
-$ s2i build git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
+$ s2i build https://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 Build a Node.js application from a local directory, using a local image, the resulting
@@ -172,14 +172,14 @@ builder image but overriding the scripts URL from local directory.  The resultin
 image will be named `java-app`:
 
 ```
-$ s2i build --scripts-url=file://s2iscripts git://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 java-app
+$ s2i build --scripts-url=file://s2iscripts https://github.com/bparees/openshift-jee-sample openshift/wildfly-100-centos7 java-app
 ```
 
 Build a Ruby application from a Git source, specifying `ref`, and using the official
 `ruby-20-centos7` builder image.  The resulting image will be named `ruby-app`:
 
 ```
-$ s2i build --ref=my-branch git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
+$ s2i build --ref=my-branch https://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 ***NOTE:*** If the ref is invalid or not present in the source repository then the build will fail.
@@ -188,7 +188,7 @@ Build a Ruby application from a Git source, overriding the scripts URL from a lo
 and specifying the scripts and sources be placed in `/opt` directory:
 
 ```
-$ s2i build --scripts-url=file://s2iscripts --destination=/opt git://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
+$ s2i build --scripts-url=file://s2iscripts --destination=/opt https://github.com/mfojtik/sinatra-app-example openshift/ruby-20-centos7 ruby-app
 ```
 
 # s2i rebuild

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -73,7 +73,7 @@ pushd ${WORK_DIR}
 
 test_debug "cloning source into working dir"
 
-git clone git://github.com/openshift/cakephp-ex &> "${WORK_DIR}/s2i-git-clone.log"
+git clone https://github.com/openshift/cakephp-ex &> "${WORK_DIR}/s2i-git-clone.log"
 check_result $? "${WORK_DIR}/s2i-git-clone.log"
 
 test_debug "s2i build with relative path without file://"
@@ -124,15 +124,15 @@ check_result $? "${WORK_DIR}/s2i-usage.log"
 
 test_debug "s2i build with git proto"
 
-s2i build git://github.com/openshift/cakephp-ex openshift/php-55-centos7 test --run=true --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log" &
+s2i build https://github.com/openshift/cakephp-ex openshift/php-55-centos7 test --run=true --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log" &
 check_result $? "${WORK_DIR}/s2i-git-proto.log"
 
 test_debug "s2i build with --run==true option"
 if [[ "$OSTYPE" == "cygwin" ]]; then
   ( cd hack/windows/sigintwrap && make )
-  hack/windows/sigintwrap/sigintwrap 's2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-90-centos7 test-jee-app --run=true --loglevel=5' &> "${WORK_DIR}/s2i-run.log" &
+  hack/windows/sigintwrap/sigintwrap 's2i build https://github.com/bparees/openshift-jee-sample openshift/wildfly-90-centos7 test-jee-app --run=true --loglevel=5' &> "${WORK_DIR}/s2i-run.log" &
 else
-  s2i build git://github.com/bparees/openshift-jee-sample openshift/wildfly-90-centos7 test-jee-app --run=true --loglevel=5 &> "${WORK_DIR}/s2i-run.log" &
+  s2i build https://github.com/bparees/openshift-jee-sample openshift/wildfly-90-centos7 test-jee-app --run=true --loglevel=5 &> "${WORK_DIR}/s2i-run.log" &
 fi
 S2I_PID=$!
 TIME_SEC=1000

--- a/pkg/create/templates/scripts.go
+++ b/pkg/create/templates/scripts.go
@@ -51,7 +51,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build git://<source code> {{.ImageName}} <application image>
+s2i build <source code path/URL> {{.ImageName}} <application image>
 
 You can then run the resulting image via:
 docker run <application image>

--- a/pkg/scm/scm.go
+++ b/pkg/scm/scm.go
@@ -45,8 +45,7 @@ func DownloaderForSource(fs util.FileSystem, s string, forceCopy bool) (build.Do
 		return &file.File{FileSystem: fs}, s, nil
 	}
 
-	// If the source is valid  Git protocol (file://, ssh://, git://, git@, etc..) use Git
-	// binary to download the sources
+	// If s is a valid Git clone spec, use git to download the source
 	g := git.New(fs)
 	ok, err := g.ValidCloneSpec(s)
 	if err != nil {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	DefaultDockerSocket = "unix:///var/run/docker.sock"
-	TestSource          = "git://github.com/pmorie/simple-html"
+	TestSource          = "https://github.com/pmorie/simple-html"
 
 	FakeBuilderImage                = "sti_test/sti-fake"
 	FakeUserImage                   = "sti_test/sti-fake-user"


### PR DESCRIPTION
Both protocols are "smart" and should have similar performance.
HTTPS is encrypted, while the Git transport is plaintext.
HTTPS verifies the certificate of the server.

The first commit is taken from #646, then I went ahead and updated other examples and tests that clone GitHub repos.