### PR TITLE
Add regression test for incremental builds

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -438,6 +438,7 @@ func (i *integrationTest) exerciseInjectionBuild(tag, imageName string, injectio
 
 func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, removePreviousImage bool, expectClean bool, checkOnBuild bool) {
 	t := i.t
+	start := time.Now()
 	config := &api.Config{
 		DockerConfig:        docker.GetDefaultDockerConfig(),
 		BuilderImage:        imageName,
@@ -504,6 +505,13 @@ func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, remove
 
 	if checkOnBuild {
 		i.fileExists(containerID, "/sti-fake/src/onbuild")
+	}
+
+	if took := time.Since(start); took > docker.DefaultDockerTimeout {
+		// https://github.com/openshift/source-to-image/issues/301 is a
+		// case where incremental builds would get stuck until the
+		// timeout.
+		t.Errorf("Test took too long (%v), some operation may have gotten stuck waiting for the DefaultDockerTimeout (%v). Inspect the logs to find operations that took long.", took, docker.DefaultDockerTimeout)
 	}
 }
 

--- a/test/integration/scripts/.s2i/bin/save-artifacts
+++ b/test/integration/scripts/.s2i/bin/save-artifacts
@@ -3,3 +3,7 @@ touch /tmp/src/save-artifacts-invoked
 
 cd /tmp/src
 tar cf - .
+
+# Write some zeros to stdout to mimic the padding that Debian's tar adds
+# https://github.com/openshift/source-to-image/issues/301#issuecomment-263598586
+dd count=1 if=/dev/zero 2> /dev/null


### PR DESCRIPTION
Ensure the build takes no more than `DefaultDockerTimeout`, what would
suggest that S2I got stuck waiting for the timeout.

This is a regression test for #301.

I've applied this patch to 12908b75a9d965425ef35a84d729f750f38eeb72 (before @jim-minter's fix) and seen the test fail:

```console
$ hack/test-integration.sh -run=TestIncrementalBuildAndRemovePreviousImage

Running integration tests ...

=== RUN   TestIncrementalBuildAndRemovePreviousImage
[...]
I1204 18:33:58.346799   28390 tar.go:434] Extracting/writing /tmp/s2i614376474/upload/artifacts/save-artifacts-invoked
I1204 18:33:58.346864   28390 tar.go:403] Done extracting tar stream
I1204 18:35:58.879113   28390 docker.go:948] Removing container "48a1c0b42ae492612affc572080b4b619a32e549277f4349ab1f6678bef0a44b" ...
[...]
--- FAIL: TestIncrementalBuildAndRemovePreviousImage (137.40s)
        integration_test.go:501: Test took too long (2m17.156475097s), some operation may have gotten stuck waiting for the DefaultDockerTimeout (2m0s). Inspect the logs to find operations that took long.
FAIL
exit status 1
FAIL    github.com/openshift/source-to-image/test/integration   137.414s

Complete
```