### PR TITLE
Make test environment variables work as advertised

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,18 +63,17 @@ To run all tests with verbose output:
 
     $ hack/test-go.sh "" -v
 
-To turn off or change the coverage mode, which is `-cover -covermode=atomic` by default, use:
-
-    $ S2I_COVER="" hack/test-go.sh
-
-To run tests without the go race detector, which is on by default, use:
+To run tests without the Go race detector, which is on by default, use:
 
     $ S2I_RACE="" hack/test-go.sh
 
-A line coverage report is run by default when testing a single package.
-To create a coverage report for all packages:
+A line coverage report is printed by default. To turn it off, use:
 
-    $ OUTPUT_COVERAGE=/tmp/reportdir hack/test-go.sh
+    $ S2I_COVER="" hack/test-go.sh
+
+To create an HTML coverage report for all packages:
+
+    $ OUTPUT_COVERAGE=/tmp/s2i-cover hack/test-go.sh
 
 
 ### Integration tests

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -26,9 +26,9 @@ find_test_dirs() {
     \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${S2I_GO_PACKAGE}/%s\n"
 }
 
-S2I_RACE=${S2I_RACE:--race}
-S2I_COVER=${S2I_COVER:--covermode=atomic}
-S2I_TIMEOUT=${S2I_TIMEOUT:--timeout 60s}
+S2I_RACE=${S2I_RACE--race}
+S2I_COVER=${S2I_COVER--cover}
+S2I_TIMEOUT=${S2I_TIMEOUT--timeout 60s}
 
 if [ "${1-}" != "" ]; then
   test_packages="$S2I_GO_PACKAGE/$1"
@@ -36,9 +36,9 @@ else
   test_packages=`find_test_dirs`
 fi
 
-OUTPUT_COVERAGE=${OUTPUT_COVERAGE:-""}
+OUTPUT_COVERAGE=${OUTPUT_COVERAGE-}
 
-if [[ -n "${S2I_COVER}" && -n "${OUTPUT_COVERAGE}" ]]; then
+if [[ -n "${OUTPUT_COVERAGE}" ]]; then
   # Iterate over packages to run coverage
   test_packages=( $test_packages )
   for test_package in "${test_packages[@]}"


### PR DESCRIPTION
`FOO=${FOO:-value}` sets FOO to 'value' if it is null (empty) or unset,
whereas `FOO=${FOO-value}` (without the colon) sets FOO only when FOO is
unset.

`FOO= hack/test-go.sh` is equivalent to `FOO="" hack/test-go.sh`, so
prefer to mention the shorter form.

Let the go tool pick the default cover mode.

Since -coverprofile implies -cover, we don't need to test S2I_COVER when
OUTPUT_COVERAGE is given.