### PR TITLE
use rhel7:inst AMI for Windows CI, to match RHEL CI

### DIFF
--- a/hack/windows/Vagrantfile
+++ b/hack/windows/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "rhel" do |rhel|
     rhel.vm.provider "aws" do |aws|
       aws.tags = {"Name" => "#{ENV['USER']}-rhel"}
-      aws.ami = "rhel7:deps"
+      aws.ami = "rhel7:inst"
     end
     rhel.vm.provision "configure-docker-server-linux"
   end


### PR DESCRIPTION
@bparees, turns out I was using the wrong AMI for the RHEL part of the Windows CI.  I haven't got to the bottom of what the difference is between the two, but it repeatedly works with inst and fails with deps.  Please merge and I'll re-enable the CI.