### PR TITLE
Build with latest available Go minor versions & tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.7.4
+  - 1.7.x
+  - master
 
 install:
   - make install-travis
@@ -14,3 +15,8 @@ notifications:
   irc: "chat.freenode.net#openshift-dev"
 
 sudo: false
+
+matrix:
+  allow_failures:
+  - go: master
+  fast_finish: true

--- a/pkg/scm/git/git_munge_test.go
+++ b/pkg/scm/git/git_munge_test.go
@@ -109,11 +109,13 @@ func TestMungeNoProtocolURL(t *testing.T) {
 		uri, err := url.Parse(scenario)
 		if err != nil {
 			t.Errorf("Could not parse url %q", scenario)
+			continue
 		}
 
 		err = gh.MungeNoProtocolURL(scenario, uri)
 		if err != nil {
 			t.Errorf("MungeNoProtocolURL returned err: %v", err)
+			continue
 		}
 
 		// reflect.DeepEqual was not dealing with url.URL correctly, have to check each field individually


### PR DESCRIPTION
This changes the build to:

* Always build with the latest minor version of the last two (supported upstream) major releases of Go (currently the latest minor version in the 1.6 and 1.7 series)
  * At present, this is building with 1.6.3, which seems to be a bug in Travis somewhere (1.6.4 is available)
  * It does correctly build with 1.7.4
* Build using the latest major version (1.8 pre-release) from the Golang git repository, but allow failures, so that we have early warning in case there are any problems due to changes in Go itself