### PR TITLE
optimize execute() func

### DIFF
--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -56,10 +56,10 @@ func (step *storePreviousImageStep) execute(ctx *postExecutorStepContext) error 
 	if step.builder.incremental && step.builder.config.RemovePreviousImage {
 		glog.V(3).Info("Executing step: store previous image")
 		ctx.previousImageID = step.getPreviousImage()
-		return nil
+	} else {
+		glog.V(3).Info("Skipping step: store previous image")
 	}
 
-	glog.V(3).Info("Skipping step: store previous image")
 	return nil
 }
 
@@ -81,10 +81,10 @@ func (step *removePreviousImageStep) execute(ctx *postExecutorStepContext) error
 	if step.builder.incremental && step.builder.config.RemovePreviousImage {
 		glog.V(3).Info("Executing step: remove previous image")
 		step.removePreviousImage(ctx.previousImageID)
-		return nil
+	} else {
+		glog.V(3).Info("Skipping step: remove previous image")
 	}
 
-	glog.V(3).Info("Skipping step: remove previous image")
 	return nil
 }
 


### PR DESCRIPTION
optimize the execute() func to keep the code  logic clear