### PR TITLE
Added a check for :z :Z SELinux flags in Volumes

### DIFF
--- a/cmd/s2i/main.go
+++ b/cmd/s2i/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -31,7 +32,6 @@ import (
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
 	"github.com/openshift/source-to-image/pkg/version"
-	"io"
 )
 
 // glog is a placeholder until the builders pass an output stream down
@@ -187,7 +187,7 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVarP(&(cfg.Description), "description", "", "", "Specify the description of the application")
 	buildCmd.Flags().VarP(&(cfg.AllowedUIDs), "allowed-uids", "u", "Specify a range of allowed user ids for the builder and runtime images")
 	buildCmd.Flags().VarP(&(cfg.Injections), "inject", "i", "Specify a directory to inject into the assemble container")
-	buildCmd.Flags().VarP(&(cfg.BuildVolumes), "volume", "v", "Specify a volume to mount into the assemble container")
+	buildCmd.Flags().StringArrayVarP(&(cfg.BuildVolumes), "volume", "v", []string{}, "Specify a volume to mount into the assemble container")
 	buildCmd.Flags().StringSliceVar(&(cfg.DropCapabilities), "cap-drop", []string{}, "Specify a comma-separated list of capabilities to drop when running Docker containers")
 	buildCmd.Flags().StringVarP(&(oldDestination), "location", "l", "",
 		"DEPRECATED: Specify a destination location for untar operation")

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"text/tabwriter"
 
@@ -78,12 +79,18 @@ func Config(config *api.Config) string {
 		if len(config.BuildVolumes) > 0 {
 			result := []string{}
 			for _, i := range config.BuildVolumes {
-				result = append(result, fmt.Sprintf("%s->%s", i.Source, i.Destination))
+				if runtime.GOOS == "windows" {
+					// We need to avoid the colon in the Windows drive letter
+					result = append(result, i[0:2]+strings.Replace(i[3:], ":", "->", 1))
+				} else {
+					result = append(result, strings.Replace(i, ":", "->", 1))
+				}
 			}
 			fmt.Fprintf(out, "Bind mounts:\t%s\n", strings.Join(result, ","))
 		}
 		return nil
 	})
+
 	if err != nil {
 		fmt.Printf("error: %v", err)
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -232,7 +232,7 @@ type Config struct {
 
 	// BuildVolumes specifies a list of volumes to mount to container running the
 	// build.
-	BuildVolumes VolumeList
+	BuildVolumes []string
 
 	// Labels specify labels and their values to be applied to the resulting image. Label keys
 	// must have non-zero length. The labels defined here override generated labels in case

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -577,7 +577,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
 		CapDrop:         config.DropCapabilities,
-		Binds:           config.BuildVolumes.AsBinds(),
+		Binds:           config.BuildVolumes,
 	}
 
 	// If there are injections specified, override the original assemble script


### PR DESCRIPTION
These flags are handled when they are passed to Docker. See [here](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/)

Fixes #587 

@bparees ptal?

edit:
My branch was pretty far behind. After the rebase, it looks like we don't check for the ':' character in filepaths. This means we need only change the call to strings.LastIndex() to strings.IndexAny(), so that we split on the first ':'