### PR TITLE
Fix misusage of regexp.MustCompile

### DIFF
--- a/pkg/build/strategies/layered/layered.go
+++ b/pkg/build/strategies/layered/layered.go
@@ -42,12 +42,19 @@ type Layered struct {
 
 // New creates a Layered builder.
 func New(config *api.Config, fs util.FileSystem, scripts build.ScriptsHandler, overrides build.Overrides) (*Layered, error) {
+	excludePattern, err := regexp.Compile(config.ExcludeRegExp)
+	if err != nil {
+		return nil, err
+	}
+
 	d, err := docker.New(config.DockerConfig, config.PullAuthentication)
 	if err != nil {
 		return nil, err
 	}
+
 	tarHandler := tar.New(fs)
-	tarHandler.SetExclusionPattern(regexp.MustCompile(config.ExcludeRegExp))
+	tarHandler.SetExclusionPattern(excludePattern)
+
 	return &Layered{
 		docker:  d,
 		config:  config,

--- a/pkg/build/strategies/layered/layered_test.go
+++ b/pkg/build/strategies/layered/layered_test.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"regexp/syntax"
 	"strings"
 	"testing"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/test"
 )
@@ -183,5 +185,15 @@ func TestBuildErrorOnBuildBlocked(t *testing.T) {
 	_, err := l.Build(l.config)
 	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed") {
 		t.Errorf("expected error from onbuild due to blocked ONBUILD, got: %v", err)
+	}
+}
+
+func TestNewWithInvalidExcludeRegExp(t *testing.T) {
+	_, err := New(&api.Config{
+		DockerConfig:  docker.GetDefaultDockerConfig(),
+		ExcludeRegExp: "[",
+	}, nil, nil, build.Overrides{})
+	if syntaxErr, ok := err.(*syntax.Error); ok && syntaxErr.Code != syntax.ErrMissingBracket {
+		t.Errorf("expected regexp compilation error, got %v", err)
 	}
 }

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -86,6 +86,11 @@ type STI struct {
 // be used for the case that the base Docker image does not have 'tar' or 'bash'
 // installed.
 func New(config *api.Config, fs util.FileSystem, overrides build.Overrides) (*STI, error) {
+	excludePattern, err := regexp.Compile(config.ExcludeRegExp)
+	if err != nil {
+		return nil, err
+	}
+
 	docker, err := dockerpkg.New(config.DockerConfig, config.PullAuthentication)
 	if err != nil {
 		return nil, err
@@ -107,7 +112,7 @@ func New(config *api.Config, fs util.FileSystem, overrides build.Overrides) (*ST
 		fs,
 	)
 	tarHandler := tar.New(fs)
-	tarHandler.SetExclusionPattern(regexp.MustCompile(config.ExcludeRegExp))
+	tarHandler.SetExclusionPattern(excludePattern)
 
 	builder := &STI{
 		installer:              inst,

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
+	"regexp/syntax"
 	"strings"
 	"testing"
 
@@ -903,5 +904,15 @@ func TestCleanup(t *testing.T) {
 		} else if !p && removedDir == "" {
 			t.Errorf("Expected working directory to be removed, but it was preserved.")
 		}
+	}
+}
+
+func TestNewWithInvalidExcludeRegExp(t *testing.T) {
+	_, err := New(&api.Config{
+		DockerConfig:  docker.GetDefaultDockerConfig(),
+		ExcludeRegExp: "(",
+	}, nil, build.Overrides{})
+	if syntaxErr, ok := err.(*syntax.Error); ok && syntaxErr.Code != syntax.ErrMissingParen {
+		t.Errorf("expected regexp compilation error, got %v", err)
 	}
 }


### PR DESCRIPTION
MustCompile is meant to simplify initialization code (package var and
init), and may panic. In runtime we should use Compile.

https://talks.golang.org/2014/readability.slide#9

Closes #613.