### PR TITLE
Ruby 2.3 image has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ You can start using `s2i` right away (see [releases](https://github.com/openshif
 with the following test sources and publicly available images:
 
 ```
-$ s2i build https://github.com/openshift/ruby-hello-world openshift/ruby-23-centos7 test-ruby-app
+$ s2i build https://github.com/openshift/ruby-hello-world centos/ruby-23-centos7 test-ruby-app
 $ docker run --rm -i -p :8080 -t test-ruby-app
 ```
 


### PR DESCRIPTION
The Ruby example doesn't work - there's no image at `openshift/ruby-23-centos7`. It's now at `centos/ruby-23-centos7`.