### PR TITLE
Build an alpine based s2i container too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,5 @@ clean:
 release: clean
 	hack/build-release.sh
 	hack/extract-release.sh
+	hack/build-alpine-images.sh
 .PHONY: release

--- a/hack/build-alpine-images.sh
+++ b/hack/build-alpine-images.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script builds an alpine based s2i image for pushing to Dockerhub
+#
+# Set S2I_IMAGE_PUSH=true to push images to a registry
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${S2I_ROOT}/hack/common.sh"
+
+# Go to the top of the tree.
+cd "${S2I_ROOT}"
+
+s2i::build::get_version_vars
+
+# Build the images
+docker build --tag openshift/s2i:${S2I_GIT_VERSION} -f "${S2I_ROOT}/images/alpine/Dockerfile" .

--- a/hack/build-alpine-images.sh
+++ b/hack/build-alpine-images.sh
@@ -18,4 +18,4 @@ cd "${S2I_ROOT}"
 s2i::build::get_version_vars
 
 # Build the images
-docker build --tag openshift/s2i:${S2I_GIT_VERSION} -f "${S2I_ROOT}/images/alpine/Dockerfile" .
+docker build --tag openshift/s2i:${S2I_GIT_VERSION} --tag openshift/s2i:latest -f "${S2I_ROOT}/images/alpine/Dockerfile" .

--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.5
+
+RUN apk add --no-cache git
+
+ADD _output/local/bin/linux/amd64/s2i /usr/local/bin/s2i


### PR DESCRIPTION
This makes a small (~35MB) container based on alpine linux that
contains s2i and git. It is built along with make release, and
should ideally be pushed to Dockerhub tagged with each release.

Note that I'm not tied to alpine - I just want something small, and we can't use
a `scratch` container here if we want git. I'm totally up for changing the base
image if needed.

This would also require an addition to the release process - someone with
access to the openshift namespace on dockerhub would need to push
the image too.

Fixes #635 