### PR TITLE
Add support for assemble-user label

### DIFF
--- a/docs/builder_image.md
+++ b/docs/builder_image.md
@@ -76,6 +76,13 @@ and placing them into the appropriate directories inside the image. The workflow
 1. Build any application artifacts.
 1. Install the artifacts into locations appropriate for running.
 
+In the case you need to assemble the Image using a different user than the runtime user defined 
+in ``USER`` directive of Dockerfile, you can achive this by the following ways:
+
+1. use the `--assemble-user` in cmd line
+1. use the label `io.openshift.s2i.assemble-user`
+
+
 #### Example `assemble` script:
 
 **NOTE**: All the examples are written in [Bash](http://www.gnu.org/software/bash/)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -50,6 +50,9 @@ const (
 	// The previous name of this label was 'io.s2i.scripts-url'. This is now
 	// deprecated.
 	ScriptsURLLabel = api.DefaultNamespace + "scripts-url"
+
+	// AssembleUserLabel is the User that will be used in the assemble process
+	AssembleUserLabel = api.DefaultNamespace + "assemble-user"
 	// DestinationLabel is the name of the Docker image LABEL that tells S2I where
 	// to place the artifacts (scripts, sources) in the builder image.
 	// The previous name of this label was 'io.s2i.destination'. This is now

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -363,3 +363,19 @@ func GetDefaultDockerConfig() *api.DockerConfig {
 
 	return cfg
 }
+
+// GetAssembleUser finds an assemble user on the given image.
+// This functions receives the config to check if the AssembleUser was defined in command line
+// If the cmd is blank, it tries to fetch the value from the Builder Image defined Label (assemble-user)
+// Otherwise it follows the common flow, using the USER defined in Dockerfile
+func GetAssembleUser(client Client, config *api.Config) (string, error) {
+	if len(config.AssembleUser) > 0 {
+		return config.AssembleUser, nil
+	}
+	d := New(client, config.PullAuthentication)
+	imageData, err := d.GetLabels(config.BuilderImage)
+	if err != nil {
+		return "", err
+	}
+	return imageData[AssembleUserLabel], nil
+}


### PR DESCRIPTION
This PR adds support for the assemble-user label in Dockerfile.

Using this label enables the user to determine a different user to assemble the image than the runtime user.

This is needed in images such as standalone PHP, that the artefacts (PHP pages) should not be writable or owned  by the same user running the daemon.

This directive is already supported by s2i cli, and this only adds the support to define this through a label called `io.openshift.s2i.assemble-user`.

The order here is: first the defined assemble-user in cli. If this is not defined, then searches for the label in the image. 

If nothing is defined, the common workflow (with no AssembleUser) will follow.

Thanks!!