### PR TITLE
Minor fixes to create template

### DIFF
--- a/pkg/create/create.go
+++ b/pkg/create/create.go
@@ -38,13 +38,13 @@ func (b *Bootstrap) AddDockerfile() {
 
 // AddReadme creates a README.md
 func (b *Bootstrap) AddReadme() {
-	b.process(templates.Readme, "README.md", 0700)
+	b.process(templates.Readme, "README.md", 0600)
 }
 
 // AddTests creates an example test for the STI image and the Makefile
 func (b *Bootstrap) AddTests() {
 	os.MkdirAll(b.DestinationDir+"/"+"test/test-app", 0700)
-	b.process(templates.Index, "test/test-app/index.html", 0700)
+	b.process(templates.Index, "test/test-app/index.html", 0600)
 	b.process(templates.TestRunScript, "test/run", 0700)
 	b.process(templates.Makefile, "Makefile", 0600)
 }

--- a/pkg/create/templates/test.go
+++ b/pkg/create/templates/test.go
@@ -163,8 +163,7 @@ cleanup
 `
 
 // Makefile contains a sample Makefile which can build and test a container.
-const Makefile = `
-IMAGE_NAME = {{.ImageName}}
+const Makefile = `IMAGE_NAME = {{.ImageName}}
 
 .PHONY: build
 build:
@@ -177,8 +176,7 @@ test:
 `
 
 // Index contains a sample index.html file.
-const Index = `
-<!doctype html>
+const Index = `<!doctype html>
 <html>
 	<head>
 		<title>Hello World!</title>


### PR DESCRIPTION
- Remove spurious newlines at the beginning of files
- README.md and index.html are no longer executable.