### PR TITLE
Validate image tag on build

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -30,7 +30,7 @@ func TestValidation(t *testing.T) {
 				DockerNetworkMode: "foobar",
 				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
 			},
-			[]Error{{ErrorInvalidValue, "dockerNetworkMode"}},
+			[]Error{{Type: ErrorInvalidValue, Field: "dockerNetworkMode"}},
 		},
 		{
 			&api.Config{
@@ -90,7 +90,7 @@ func TestValidation(t *testing.T) {
 				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
 				Labels:            map[string]string{"some": "thing", "": "emptykey"},
 			},
-			[]Error{{ErrorInvalidValue, "labels"}},
+			[]Error{{Type: ErrorInvalidValue, Field: "labels"}},
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
Validates the output tag argument using docker's validation code.
Output:
```
$ s2i build . openshift/origin-release:golang-1.8 MyImage:Tag
ERROR: Invalid value specified for "tag": repository name must be lowercase
...
[ command help ]
```

Fixes https://github.com/openshift/source-to-image/issues/826