### PR TITLE
Add force remove option to layered image builds

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -1134,6 +1134,7 @@ func (d *stiDocker) BuildImage(opts BuildImageOptions) error {
 		NoCache:        true,
 		SuppressOutput: false,
 		Remove:         true,
+		ForceRemove:    true,
 	}
 	if opts.CGroupLimits != nil {
 		dockerOpts.Memory = opts.CGroupLimits.MemoryLimitBytes


### PR DESCRIPTION
Add force remove option to cleanup failed build containers when running a layered build.
Related to https://github.com/openshift/origin/pull/17283