### PR TITLE
Remove the out-of-dated docker engine-api related hack

### DIFF
--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -385,12 +384,6 @@ func GetDefaultDockerConfig() *api.DockerConfig {
 
 	if cfg.Endpoint = os.Getenv("DOCKER_HOST"); cfg.Endpoint == "" {
 		cfg.Endpoint = client.DefaultDockerHost
-
-		// TODO: remove this when we bump engine-api to >=
-		// cf82c64276ebc2501e72b241f9fdc1e21e421743
-		if runtime.GOOS == "darwin" {
-			cfg.Endpoint = "unix:///var/run/docker.sock"
-		}
 	}
 
 	certPath := os.Getenv("DOCKER_CERT_PATH")


### PR DESCRIPTION
Since the code does not rely on docker's engine-api now, this hack should also be removed.