### PR TITLE
Miscellaneous cleanup and refactoring

### DIFF
--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -23,7 +23,7 @@ func Config(client docker.Client, config *api.Config) string {
 		if len(config.Description) > 0 {
 			fmt.Fprintf(out, "Description:\t%s\n", config.Description)
 		}
-		describeBuilderImage(client, config, config.BuilderImage, out)
+		describeBuilderImage(client, config, out)
 		describeRuntimeImage(config, out)
 		fmt.Fprintf(out, "Source:\t%s\n", config.Source)
 		if len(config.ContextDir) > 0 {
@@ -94,7 +94,7 @@ func Config(client docker.Client, config *api.Config) string {
 	return out
 }
 
-func describeBuilderImage(client docker.Client, config *api.Config, image string, out io.Writer) {
+func describeBuilderImage(client docker.Client, config *api.Config, out io.Writer) {
 	c := &api.Config{
 		DockerConfig:       config.DockerConfig,
 		PullAuthentication: config.PullAuthentication,

--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -207,16 +207,16 @@ func (step *downloadFilesFromBuilderImageStep) execute(ctx *postExecutorStepCont
 				return fmt.Errorf("could not create directory %q: %v", dstDir, err)
 			}
 
-			file := filepath.Base(artifact.Source)
-			old := filepath.Join(artifactsDir, file)
-			new := filepath.Join(artifactsDir, dstSubDir, file)
-			glog.V(5).Infof("Renaming %q to %q", old, new)
-			if err := step.fs.Rename(old, new); err != nil {
+			currentFile := filepath.Base(artifact.Source)
+			oldFile := filepath.Join(artifactsDir, currentFile)
+			newFile := filepath.Join(artifactsDir, dstSubDir, currentFile)
+			glog.V(5).Infof("Renaming %q to %q", oldFile, newFile)
+			if err := step.fs.Rename(oldFile, newFile); err != nil {
 				step.builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(
 					utilstatus.ReasonFSOperationFailed,
 					utilstatus.ReasonMessageFSOperationFailed,
 				)
-				return fmt.Errorf("could not rename %q -> %q: %v", old, new, err)
+				return fmt.Errorf("could not rename %q -> %q: %v", oldFile, newFile, err)
 			}
 		}
 	}
@@ -484,7 +484,7 @@ func downloadAndExtractFileFromContainer(docker dockerpkg.Docker, tar s2itar.Tar
 	}
 
 	// after writing to the file descriptor we need to rewind pointer to the beginning of the file before next reading
-	if _, err := fd.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := fd.Seek(0, io.SeekStart); err != nil {
 		res := utilstatus.NewFailureReason(
 			utilstatus.ReasonGenericS2IBuildFailed,
 			utilstatus.ReasonMessageGenericS2iBuildFailed,

--- a/pkg/build/strategies/sti/postexecutorstep_test.go
+++ b/pkg/build/strategies/sti/postexecutorstep_test.go
@@ -33,11 +33,11 @@ func TestStorePreviousImageStep(t *testing.T) {
 		builder.config.RemovePreviousImage = true
 		builder.config.Tag = testCase.expectedPreviousImageTag
 
-		docker := builder.docker.(*docker.FakeDocker)
-		docker.GetImageIDResult = testCase.expectedPreviousImageID
-		docker.GetImageIDError = testCase.imageIDError
+		fakeDocker := builder.docker.(*docker.FakeDocker)
+		fakeDocker.GetImageIDResult = testCase.expectedPreviousImageID
+		fakeDocker.GetImageIDError = testCase.imageIDError
 
-		step := &storePreviousImageStep{builder: builder, docker: docker}
+		step := &storePreviousImageStep{builder: builder, docker: fakeDocker}
 
 		ctx := &postExecutorStepContext{}
 
@@ -45,8 +45,8 @@ func TestStorePreviousImageStep(t *testing.T) {
 			t.Fatalf("should exit without error, but it returned %v", err)
 		}
 
-		if docker.GetImageIDImage != testCase.expectedPreviousImageTag {
-			t.Errorf("should invoke docker.GetImageID(%q) but invoked with %q", testCase.expectedPreviousImageTag, docker.GetImageIDImage)
+		if fakeDocker.GetImageIDImage != testCase.expectedPreviousImageTag {
+			t.Errorf("should invoke fakeDocker.GetImageID(%q) but invoked with %q", testCase.expectedPreviousImageTag, fakeDocker.GetImageIDImage)
 		}
 
 		if ctx.previousImageID != testCase.expectedPreviousImageID {
@@ -80,10 +80,10 @@ func TestRemovePreviousImageStep(t *testing.T) {
 		builder.incremental = true
 		builder.config.RemovePreviousImage = true
 
-		docker := builder.docker.(*docker.FakeDocker)
-		docker.RemoveImageError = testCase.removeImageError
+		fakeDocker := builder.docker.(*docker.FakeDocker)
+		fakeDocker.RemoveImageError = testCase.removeImageError
 
-		step := &removePreviousImageStep{builder: builder, docker: docker}
+		step := &removePreviousImageStep{builder: builder, docker: fakeDocker}
 
 		ctx := &postExecutorStepContext{previousImageID: testCase.expectedPreviousImageID}
 
@@ -91,8 +91,8 @@ func TestRemovePreviousImageStep(t *testing.T) {
 			t.Fatalf("should exit without error, but it returned %v", err)
 		}
 
-		if docker.RemoveImageName != testCase.expectedPreviousImageID {
-			t.Errorf("should invoke docker.RemoveImage(%q) but invoked with %q", testCase.expectedPreviousImageID, docker.RemoveImageName)
+		if fakeDocker.RemoveImageName != testCase.expectedPreviousImageID {
+			t.Errorf("should invoke fakeDocker.RemoveImage(%q) but invoked with %q", testCase.expectedPreviousImageID, fakeDocker.RemoveImageName)
 		}
 	}
 }
@@ -147,11 +147,11 @@ func TestCommitImageStep(t *testing.T) {
 		builder.config.Labels = configLabels
 		builder.env = expectedEnv
 
-		docker := builder.docker.(*docker.FakeDocker)
-		docker.CommitContainerResult = expectedImageID
-		docker.GetImageUserResult = expectedImageUser
-		docker.GetImageEntrypointResult = expectedEntrypoint
-		docker.Labels = baseImageLabels
+		fakeDocker := builder.docker.(*docker.FakeDocker)
+		fakeDocker.CommitContainerResult = expectedImageID
+		fakeDocker.GetImageUserResult = expectedImageUser
+		fakeDocker.GetImageEntrypointResult = expectedEntrypoint
+		fakeDocker.Labels = baseImageLabels
 
 		ctx := &postExecutorStepContext{
 			containerID: expectedContainerID,
@@ -164,7 +164,7 @@ func TestCommitImageStep(t *testing.T) {
 			ctx.destination = testCase.destination
 		}
 
-		step := &commitImageStep{builder: builder, docker: docker}
+		step := &commitImageStep{builder: builder, docker: fakeDocker}
 
 		if err := step.execute(ctx); err != nil {
 			t.Fatalf("should exit without error, but it returned %v", err)
@@ -174,7 +174,7 @@ func TestCommitImageStep(t *testing.T) {
 			t.Errorf("should set ImageID field to %q but it's %q", expectedImageID, ctx.imageID)
 		}
 
-		commitOpts := docker.CommitContainerOpts
+		commitOpts := fakeDocker.CommitContainerOpts
 
 		if len(commitOpts.Command) != 1 {
 			t.Errorf("should commit container with Command: %q, but committed with %q", testCase.expectedImageCmd, commitOpts.Command)

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -750,9 +750,9 @@ func (builder *STI) initPostExecutorSteps() {
 }
 
 func isMissingRequirements(text string) bool {
-	tar, _ := regexp.MatchString(`.*tar.*not found`, text)
-	sh, _ := regexp.MatchString(`.*/bin/sh.*no such file or directory`, text)
-	return tar || sh
+	tarCommand, _ := regexp.MatchString(`.*tar.*not found`, text)
+	shCommand, _ := regexp.MatchString(`.*/bin/sh.*no such file or directory`, text)
+	return tarCommand || shCommand
 }
 
 func includes(arr []string, str string) bool {

--- a/pkg/build/strategies/sti/sti_test.go
+++ b/pkg/build/strategies/sti/sti_test.go
@@ -463,7 +463,7 @@ func TestSaveArtifacts(t *testing.T) {
 	bh := testBuildHandler()
 	bh.config.WorkingDir = "/working-dir"
 	bh.config.Tag = "image/tag"
-	fs := bh.fs.(*testfs.FakeFileSystem)
+	fakeFS := bh.fs.(*testfs.FakeFileSystem)
 	fd := bh.docker.(*docker.FakeDocker)
 	th := bh.tar.(*test.FakeTar)
 	err := bh.Save(bh.config)
@@ -471,9 +471,9 @@ func TestSaveArtifacts(t *testing.T) {
 		t.Errorf("Unexpected error when saving artifacts: %v", err)
 	}
 	expectedArtifactDir := "/working-dir/upload/artifacts"
-	if filepath.ToSlash(fs.MkdirDir) != expectedArtifactDir {
+	if filepath.ToSlash(fakeFS.MkdirDir) != expectedArtifactDir {
 		t.Errorf("Mkdir was not called with the expected directory: %s",
-			fs.MkdirDir)
+			fakeFS.MkdirDir)
 	}
 	if fd.RunContainerOpts.Image != bh.config.Tag {
 		t.Errorf("Unexpected image sent to RunContainer: %s",
@@ -489,7 +489,7 @@ func TestSaveArtifactsCustomTag(t *testing.T) {
 	bh.config.WorkingDir = "/working-dir"
 	bh.config.IncrementalFromTag = "custom/tag"
 	bh.config.Tag = "image/tag"
-	fs := bh.fs.(*testfs.FakeFileSystem)
+	fakeFS := bh.fs.(*testfs.FakeFileSystem)
 	fd := bh.docker.(*docker.FakeDocker)
 	th := bh.tar.(*test.FakeTar)
 	err := bh.Save(bh.config)
@@ -497,9 +497,9 @@ func TestSaveArtifactsCustomTag(t *testing.T) {
 		t.Errorf("Unexpected error when saving artifacts: %v", err)
 	}
 	expectedArtifactDir := "/working-dir/upload/artifacts"
-	if filepath.ToSlash(fs.MkdirDir) != expectedArtifactDir {
+	if filepath.ToSlash(fakeFS.MkdirDir) != expectedArtifactDir {
 		t.Errorf("Mkdir was not called with the expected directory: %s",
-			fs.MkdirDir)
+			fakeFS.MkdirDir)
 	}
 	if fd.RunContainerOpts.Image != bh.config.IncrementalFromTag {
 		t.Errorf("Unexpected image sent to RunContainer: %s",
@@ -700,8 +700,8 @@ func TestPrepareUseCustomRuntimeArtifacts(t *testing.T) {
 func TestPrepareFailForEmptyRuntimeArtifacts(t *testing.T) {
 	builder := newFakeSTI(&FakeSTI{})
 
-	docker := builder.docker.(*docker.FakeDocker)
-	docker.AssembleInputFilesResult = ""
+	fakeDocker := builder.docker.(*docker.FakeDocker)
+	fakeDocker.AssembleInputFilesResult = ""
 
 	config := builder.config
 	config.RuntimeImage = "my-app"
@@ -748,8 +748,8 @@ func TestPrepareRuntimeArtifactsValidation(t *testing.T) {
 			if mappingFromUser {
 				config.RuntimeArtifacts.Set(testCase.mapping)
 			} else {
-				docker := builder.docker.(*docker.FakeDocker)
-				docker.AssembleInputFilesResult = testCase.mapping
+				fakeDocker := builder.docker.(*docker.FakeDocker)
+				fakeDocker.AssembleInputFilesResult = testCase.mapping
 			}
 
 			err := builder.Prepare(config)
@@ -769,8 +769,8 @@ func TestPrepareSetRuntimeArtifacts(t *testing.T) {
 
 		builder := newFakeSTI(&FakeSTI{})
 
-		docker := builder.docker.(*docker.FakeDocker)
-		docker.AssembleInputFilesResult = mapping
+		fakeDocker := builder.docker.(*docker.FakeDocker)
+		fakeDocker.AssembleInputFilesResult = mapping
 
 		config := builder.config
 		config.RuntimeImage = "my-app"

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -25,7 +25,7 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 	var buildInfo api.BuildInfo
 	var err error
 
-	fs := fs.NewFileSystem()
+	fileSystem := fs.NewFileSystem()
 
 	startTime := time.Now()
 
@@ -51,7 +51,7 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 	// if we're blocking onbuild, just do a normal s2i build flow
 	// which won't do a docker build and invoke the onbuild commands
 	if image.OnBuild && !config.BlockOnBuild {
-		builder, err = onbuild.New(client, config, fs, overrides)
+		builder, err = onbuild.New(client, config, fileSystem, overrides)
 		if err != nil {
 			buildInfo.FailureReason = utilstatus.NewFailureReason(
 				utilstatus.ReasonGenericS2IBuildFailed,
@@ -62,7 +62,7 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 		return builder, buildInfo, nil
 	}
 
-	builder, err = sti.New(client, config, fs, overrides)
+	builder, err = sti.New(client, config, fileSystem, overrides)
 	if err != nil {
 		buildInfo.FailureReason = utilstatus.NewFailureReason(
 			utilstatus.ReasonGenericS2IBuildFailed,

--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -325,12 +325,11 @@ func isOnbuildAllowed(directives []string, allowed *user.RangeList) bool {
 }
 
 func extractUser(userSpec string) string {
-	user := userSpec
-	if strings.Contains(user, ":") {
+	if strings.Contains(userSpec, ":") {
 		parts := strings.SplitN(userSpec, ":", 2)
-		user = parts[0]
+		return strings.TrimSpace(parts[0])
 	}
-	return strings.TrimSpace(user)
+	return strings.TrimSpace(userSpec)
 }
 
 // CheckReachable returns if the Docker daemon is reachable from s2i

--- a/pkg/scm/git/git.go
+++ b/pkg/scm/git/git.go
@@ -55,16 +55,6 @@ func cloneConfigToArgs(opts CloneConfig) []string {
 	return result
 }
 
-func stringInSlice(s string, slice []string) bool {
-	for _, element := range slice {
-		if s == element {
-			return true
-		}
-	}
-
-	return false
-}
-
 // followGitSubmodule looks at a .git /file/ and tries to retrieve from inside
 // it the gitdir value, which is supposed to indicate the location of the
 // corresponding .git /directory/.  Note: the gitdir value should point directly

--- a/pkg/scm/git/git_test.go
+++ b/pkg/scm/git/git_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIsValidGitRepository(t *testing.T) {
-	fs := fs.NewFileSystem()
+	fileSystem := fs.NewFileSystem()
 
 	// a local git repo with a commit
 	d, err := CreateLocalGitDirectory()
@@ -22,11 +22,11 @@ func TestIsValidGitRepository(t *testing.T) {
 	}
 	defer os.RemoveAll(d)
 
-	ok, err := IsLocalNonBareGitRepository(fs, d)
+	ok, err := IsLocalNonBareGitRepository(fileSystem, d)
 	if !ok || err != nil {
 		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
 	}
-	empty, err := LocalNonBareGitRepositoryIsEmpty(fs, d)
+	empty, err := LocalNonBareGitRepositoryIsEmpty(fileSystem, d)
 	if empty || err != nil {
 		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
 	}
@@ -38,11 +38,11 @@ func TestIsValidGitRepository(t *testing.T) {
 	}
 	defer os.RemoveAll(d)
 
-	ok, err = IsLocalNonBareGitRepository(fs, d)
+	ok, err = IsLocalNonBareGitRepository(fileSystem, d)
 	if !ok || err != nil {
 		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
 	}
-	empty, err = LocalNonBareGitRepositoryIsEmpty(fs, d)
+	empty, err = LocalNonBareGitRepositoryIsEmpty(fileSystem, d)
 	if !empty || err != nil {
 		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
 	}
@@ -50,7 +50,7 @@ func TestIsValidGitRepository(t *testing.T) {
 	// a directory which is not a git repo
 	d = filepath.Join(d, ".git")
 
-	ok, err = IsLocalNonBareGitRepository(fs, d)
+	ok, err = IsLocalNonBareGitRepository(fileSystem, d)
 	if ok || err != nil {
 		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
 	}
@@ -62,11 +62,11 @@ func TestIsValidGitRepository(t *testing.T) {
 	}
 	defer os.RemoveAll(d)
 
-	ok, err = IsLocalNonBareGitRepository(fs, filepath.Join(d, "submodule"))
+	ok, err = IsLocalNonBareGitRepository(fileSystem, filepath.Join(d, "submodule"))
 	if !ok || err != nil {
 		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
 	}
-	empty, err = LocalNonBareGitRepositoryIsEmpty(fs, filepath.Join(d, "submodule"))
+	empty, err = LocalNonBareGitRepositoryIsEmpty(fileSystem, filepath.Join(d, "submodule"))
 	if empty || err != nil {
 		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
 	}

--- a/pkg/scm/git/url_test.go
+++ b/pkg/scm/git/url_test.go
@@ -209,7 +209,7 @@ func TestParse(t *testing.T) {
 	)
 
 	for _, test := range tests {
-		url, err := Parse(test.rawurl)
+		parsedURL, err := Parse(test.rawurl)
 		if test.expectedError != (err != nil) {
 			t.Errorf("%s: Parse() returned err: %v", test.rawurl, err)
 		}
@@ -217,16 +217,16 @@ func TestParse(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(url, test.expectedGitURL) {
-			t.Errorf("%s: Parse() returned\n\t%#v\nWanted\n\t%#v", test.rawurl, url, test.expectedGitURL)
+		if !reflect.DeepEqual(parsedURL, test.expectedGitURL) {
+			t.Errorf("%s: Parse() returned\n\t%#v\nWanted\n\t%#v", test.rawurl, parsedURL, test.expectedGitURL)
 		}
 
-		if url.String() != test.rawurl {
-			t.Errorf("%s: String() returned %s", test.rawurl, url.String())
+		if parsedURL.String() != test.rawurl {
+			t.Errorf("%s: String() returned %s", test.rawurl, parsedURL.String())
 		}
 
-		if url.StringNoFragment() != strings.SplitN(test.rawurl, "#", 2)[0] {
-			t.Errorf("%s: StringNoFragment() returned %s", test.rawurl, url.StringNoFragment())
+		if parsedURL.StringNoFragment() != strings.SplitN(test.rawurl, "#", 2)[0] {
+			t.Errorf("%s: StringNoFragment() returned %s", test.rawurl, parsedURL.StringNoFragment())
 		}
 	}
 }

--- a/pkg/scripts/install_test.go
+++ b/pkg/scripts/install_test.go
@@ -180,8 +180,8 @@ func TestInstallRequiredFromSource(t *testing.T) {
 			t.Errorf("expected %q has result URL %s, got %#v", s, filepath.FromSlash(sourcesRootAbbrev+"/.s2i/bin/"+s), result)
 		}
 		chmodCalled := false
-		fs := config.fs.(*testfs.FakeFileSystem)
-		for _, f := range fs.ChmodFile {
+		filesystem := config.fs.(*testfs.FakeFileSystem)
+		for _, f := range filesystem.ChmodFile {
 			if filepath.ToSlash(f) == "/workdir/upload/scripts/"+s {
 				chmodCalled = true
 			}

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -400,7 +400,7 @@ func (t *stiTar) extractFile(dir string, header *tar.Header, tarReader io.Reader
 		return err
 	}
 	if written != header.Size {
-		return fmt.Errorf("Wrote %d bytes, expected to write %d", written, header.Size)
+		return fmt.Errorf("wrote %d bytes, expected to write %d", written, header.Size)
 	}
 	return t.Chmod(path, header.FileInfo().Mode())
 }

--- a/pkg/util/fs/fs.go
+++ b/pkg/util/fs/fs.go
@@ -281,8 +281,8 @@ func (h *fs) RemoveDirectory(dir string) error {
 	// TODO: Remove this workaround when we switch to go 1.7 -- os.RemoveAll should
 	// be fixed for Windows in that release.  https://github.com/golang/go/issues/9606
 	if runtime.GOOS == "windows" {
-		cmd := exec.Command("cmd.exe", "/c", fmt.Sprintf("rd /s /q %s", dir))
-		output, err := cmd.Output()
+		command := exec.Command("cmd.exe", "/c", fmt.Sprintf("rd /s /q %s", dir))
+		output, err := command.Output()
 		if err != nil {
 			glog.Errorf("Error removing directory %q: %v %s", dir, err, string(output))
 			return err

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -64,7 +64,7 @@ func ExpandInjectedFiles(fs fs.FileSystem, injections api.VolumeList) ([]string,
 			if f.Mode()&os.ModeSymlink != 0 {
 				linkDest, err := filepath.EvalSymlinks(path)
 				if err != nil {
-					return fmt.Errorf("Unable to evaluate symlink [%v]: %v", path, err)
+					return fmt.Errorf("unable to evaluate symlink [%v]: %v", path, err)
 				}
 				// Evaluate the destination of the link.
 				f, err = os.Lstat(linkDest)

--- a/pkg/util/status/build_status_test.go
+++ b/pkg/util/status/build_status_test.go
@@ -71,7 +71,7 @@ func TestUpdateStageDuration(t *testing.T) {
 	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullBuilderImage, time.Now(), endTime)
 
 	if buildInfo.Stages[0].DurationMilliseconds != (endTime.Sub(startTime).Nanoseconds() / int64(time.Millisecond)) {
-		t.Errorf("Stage Duration was not updated, expected %#v, got %#v", (endTime.Sub(startTime).Nanoseconds() / int64(time.Millisecond)), buildInfo.Stages[0].DurationMilliseconds)
+		t.Errorf("Stage Duration was not updated, expected %#v, got %#v", endTime.Sub(startTime).Nanoseconds()/int64(time.Millisecond), buildInfo.Stages[0].DurationMilliseconds)
 	}
 
 }


### PR DESCRIPTION
I was messing around with Jetbrains GoLand and ran it's code inspection
against openshift/source-to-image and it found quite a few things, so
I went through and picked the ones that seemed like good ones to fix
and fixed them.

Some of the issues that were fixed consist of:

 - Removing unused function parameters
 - Removing unused non-exported function
 - Replacing deprecated os.SEEK_SET with io.SeekStart
 - Replacing deprecated msg.ProgressMessage with msg.Progress.Current
 - Removing duplicate parenthesis
 - Renaming variables that could mask imports
-  Renaming variable that used reserved word (new)
 - Downcasing the first letter of error messages

I think that is mostly it, I am sure there will need to be some updates
to openshift/origin in response to these updates.