### PR TITLE
Fixes tar is nil on postExecutorSecondStageSteps.commitImageStep

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -741,6 +741,7 @@ func (builder *STI) initPostExecutorSteps() {
 				image:   builder.config.RuntimeImage,
 				builder: builder,
 				docker:  builder.docker,
+				tar:     builder.tar,
 			},
 			&reportSuccessStep{
 				builder: builder,


### PR DESCRIPTION
It looks like /tmp/.s2i/image_metadata.json was never meant to be created during the assemble-runtime step, only during the assemble step, so tar was nil in that specific commitImageStep

Fixes #838