### PR TITLE
Keep Option for Injected Files

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -266,8 +266,12 @@ type CGroupLimits struct {
 
 // VolumeSpec represents a single volume mount point.
 type VolumeSpec struct {
-	Source      string
+	// Source is a reference to the volume source.
+	Source string
+	// Destination is the path to mount the volume to - absolute or relative.
 	Destination string
+	// Keep indicates if the mounted data should be kept in the final image.
+	Keep bool
 }
 
 // VolumeList contains list of VolumeSpec.

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -613,7 +613,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 			return err
 		}
 		config.Injections = util.FixInjectionsWithRelativePath(workdir, config.Injections)
-		injectedFiles, err := util.ExpandInjectedFiles(builder.fs, config.Injections)
+		truncatedFiles, err := util.ListFilesToTruncate(builder.fs, config.Injections)
 		if err != nil {
 			builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(
 				utilstatus.ReasonInstallScriptsFailed,
@@ -621,7 +621,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 			)
 			return err
 		}
-		rmScript, err := util.CreateInjectedFilesRemovalScript(injectedFiles, "/tmp/rm-injections")
+		rmScript, err := util.CreateTruncateFilesScript(truncatedFiles, "/tmp/rm-injections")
 		if len(rmScript) != 0 {
 			defer os.Remove(rmScript)
 		}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -403,6 +403,12 @@ func (i *integrationTest) exerciseInjectionBuild(tag, imageName string, injectio
 			t.Errorf("injectionList.Set() failed with error %s\n", err)
 		}
 	}
+	// For test purposes, keep at least one injected source
+	var keptVolume *api.VolumeSpec
+	if len(injectionList) > 0 {
+		injectionList[0].Keep = true
+		keptVolume = &injectionList[0]
+	}
 	config := &api.Config{
 		DockerConfig:      docker.GetDefaultDockerConfig(),
 		BuilderImage:      imageName,
@@ -432,15 +438,35 @@ func (i *integrationTest) exerciseInjectionBuild(tag, imageName string, injectio
 	i.fileExists(containerID, "/sti-fake/relative-secret-delivered")
 
 	// Make sure the injected file does not exists in resulting image
-	files, err := util.ExpandInjectedFiles(fs.NewFileSystem(), injectionList)
+	testFs := fs.NewFileSystem()
+	files, err := util.ListFilesToTruncate(testFs, injectionList)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	for _, f := range files {
-		if exitCode := i.runInImage(tag, "test -s "+f); exitCode == 0 {
-			t.Errorf("The file %q must be empty", f)
+		if err = i.testFile(tag, f); err == nil {
+			t.Errorf("The file %q must be empty or not exist", f)
 		}
 	}
+	if keptVolume != nil {
+		keptFiles, err := util.ListFiles(testFs, *keptVolume)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		for _, f := range keptFiles {
+			if err = i.testFile(tag, f); err != nil {
+				t.Errorf("The file %q must exist and not be empty", f)
+			}
+		}
+	}
+}
+
+func (i *integrationTest) testFile(tag, path string) error {
+	exitCode := i.runInImage(tag, "test -s "+path)
+	if exitCode != 0 {
+		return fmt.Errorf("file %s does not exist or is empty in the container %s", path, tag)
+	}
+	return nil
 }
 
 func (i *integrationTest) exerciseIncrementalBuild(tag, imageName string, removePreviousImage bool, expectClean bool, checkOnBuild bool) {


### PR DESCRIPTION
Adding a `Keep` option to `VolumeSpec` so that files can be kept in s2i builds.

This will be used to support the injection of `ConfigMap` build sources, which should not be truncated.

Trello card: https://trello.com/c/RMKJxJUm/1020-5-allow-using-a-configmap-as-an-input-to-a-build-builds