### PR TITLE
[3.9] Check Assemble Users Against Allowed UIDs

### DIFF
--- a/hack/build-test-images.sh
+++ b/hack/build-test-images.sh
@@ -22,6 +22,8 @@ s2i::build_test_image() {
   cd "${S2I_ROOT}"
 
   s2i::build_test_image sti-fake
+  s2i::build_test_image sti-fake-assemble-root
+  s2i::build_test_image sti-fake-assemble-user
   s2i::build_test_image sti-fake-env
   s2i::build_test_image sti-fake-user
   s2i::build_test_image sti-fake-scripts

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -13,7 +13,7 @@ s2i::cleanup() {
 
 readonly img_count="$(docker images | grep -c sti_test/sti-fake || :)"
 
-if [ "${img_count}" != "10" ]; then
+if [ "${img_count}" != "12" ]; then
     echo "Missing test images, run 'hack/build-test-images.sh' and try again."
     exit 1
 fi

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -79,11 +79,11 @@ check_result $? "${WORK_DIR}/s2i-git-clone.log"
 
 test_debug "s2i build with relative path without file://"
 
-s2i build cakephp-ex openshift/php-55-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-rel-noproto.log"
+s2i build cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-rel-noproto.log"
 check_result $? "${WORK_DIR}/s2i-rel-noproto.log"
 
 test_debug "s2i build with volume options"
-s2i build cakephp-ex openshift/php-55-centos7 test --volume "${WORK_DIR}:/home/:z" --loglevel=5 &> "${WORK_DIR}/s2i-volume-correct.log"
+s2i build cakephp-ex docker.io/centos/php-70-centos7 test --volume "${WORK_DIR}:/home/:z" --loglevel=5 &> "${WORK_DIR}/s2i-volume-correct.log"
 check_result $? "${WORK_DIR}/s2i-volume-correct.log"
 
 popd
@@ -96,12 +96,12 @@ else
   S2I_WORK_DIR_URL="file://${S2I_WORK_DIR}/cakephp-ex"
 fi
 
-s2i build "${S2I_WORK_DIR_URL}" openshift/php-55-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-proto.log"
+s2i build "${S2I_WORK_DIR_URL}" docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-proto.log"
 check_result $? "${WORK_DIR}/s2i-abs-proto.log"
 
 test_debug "s2i build with absolute path without file://"
 
-s2i build "${S2I_WORK_DIR}/cakephp-ex" openshift/php-55-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-noproto.log"
+s2i build "${S2I_WORK_DIR}/cakephp-ex" docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-noproto.log"
 check_result $? "${WORK_DIR}/s2i-abs-noproto.log"
 
 ## don't do ssh tests here because credentials are needed (even for the git user), which
@@ -110,7 +110,7 @@ check_result $? "${WORK_DIR}/s2i-abs-noproto.log"
 test_debug "s2i build with non-git repo file location"
 
 rm -rf "${WORK_DIR}/cakephp-ex/.git"
-s2i build "${S2I_WORK_DIR}/cakephp-ex" openshift/php-55-centos7 test --loglevel=5 --loglevel=5 &> "${WORK_DIR}/s2i-non-repo.log"
+s2i build "${S2I_WORK_DIR}/cakephp-ex" docker.io/centos/php-70-centos7 test --loglevel=5 --loglevel=5 &> "${WORK_DIR}/s2i-non-repo.log"
 check_result $? ""
 grep "Copying sources" "${WORK_DIR}/s2i-non-repo.log"
 check_result $? "${WORK_DIR}/s2i-non-repo.log"
@@ -123,13 +123,13 @@ check_result $? "${WORK_DIR}/s2i-rebuild.log"
 
 test_debug "s2i usage"
 
-s2i usage openshift/ruby-20-centos7 --loglevel=5 &> "${WORK_DIR}/s2i-usage.log"
+s2i usage docker.io/centos/ruby-24-centos7 --loglevel=5 &> "${WORK_DIR}/s2i-usage.log"
 check_result $? ""
 grep "Sample invocation" "${WORK_DIR}/s2i-usage.log"
 check_result $? "${WORK_DIR}/s2i-usage.log"
 
 test_debug "s2i build with overriding assemble/run scripts"
-s2i build https://github.com/openshift/source-to-image openshift/php-55-centos7 test --context-dir=test_apprepo >& "${WORK_DIR}/s2i-override-build.log"
+s2i build https://github.com/openshift/source-to-image docker.io/centos/php-70-centos7 test --context-dir=test_apprepo >& "${WORK_DIR}/s2i-override-build.log"
 grep "Running custom assemble" "${WORK_DIR}/s2i-override-build.log"
 check_result $? "${WORK_DIR}/s2i-override-build.log"
 docker run test >& "${WORK_DIR}/s2i-override-run.log"
@@ -137,7 +137,7 @@ grep "Running custom run" "${WORK_DIR}/s2i-override-run.log"
 check_result $? "${WORK_DIR}/s2i-override-run.log"
 
 test_debug "s2i build with remote git repo"
-s2i build https://github.com/openshift/cakephp-ex openshift/php-55-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
+s2i build https://github.com/openshift/cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
 check_result $? "${WORK_DIR}/s2i-git-proto.log"
 
 test_debug "s2i build with --run==true option"
@@ -145,7 +145,7 @@ if [[ "$OSTYPE" == "cygwin" ]]; then
   ( cd hack/windows/sigintwrap && make )
   hack/windows/sigintwrap/sigintwrap 's2i build --ref=10.x --context-dir=helloworld https://github.com/wildfly/quickstart openshift/wildfly-101-centos7 test-jee-app --run=true --loglevel=5' &> "${WORK_DIR}/s2i-run.log" &
 else
-  s2i build --ref=10.x --context-dir=helloworld https://github.com/wildfly/quickstart openshift/wildfly-101-centos7 test-jee-app --run=true --loglevel=5 &> "${WORK_DIR}/s2i-run.log" &
+  s2i build --ref=10.x --context-dir=helloworld https://github.com/wildfly/quickstart docker.io/openshift/wildfly-101-centos7 test-jee-app --run=true --loglevel=5 &> "${WORK_DIR}/s2i-run.log" &
 fi
 S2I_PID=$!
 TIME_SEC=1000

--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -103,13 +103,14 @@ func describeBuilderImage(client docker.Client, config *api.Config, out io.Write
 		Tag:                config.Tag,
 		IncrementalAuthentication: config.IncrementalAuthentication,
 	}
-	pr, err := docker.GetBuilderImage(client, c)
+	dkr := docker.New(client, c.PullAuthentication)
+	builderImage, err := docker.GetBuilderImage(dkr, c)
 	if err == nil {
-		build.GenerateConfigFromLabels(c, pr)
+		build.GenerateConfigFromLabels(c, builderImage)
 		if len(c.DisplayName) > 0 {
 			fmt.Fprintf(out, "Builder Name:\t%s\n", c.DisplayName)
 		}
-		fmt.Fprintf(out, "Builder Image:\t%s\n", config.BuilderImage)
+		fmt.Fprintf(out, "Builder Image:\t%s\n", c.BuilderImage)
 		if len(c.BuilderImageVersion) > 0 {
 			fmt.Fprintf(out, "Builder Image Version:\t%s\n", c.BuilderImageVersion)
 		}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -270,7 +270,7 @@ func (builder *STI) Prepare(config *api.Config) error {
 
 	if len(config.RuntimeImage) > 0 {
 		startTime := time.Now()
-		dockerpkg.GetRuntimeImage(config, builder.runtimeDocker)
+		dockerpkg.GetRuntimeImage(builder.runtimeDocker, config)
 		builder.result.BuildInfo.Stages = api.RecordStageAndStepInfo(builder.result.BuildInfo.Stages, api.StagePullImages, api.StepPullRuntimeImage, startTime, time.Now())
 
 		if err != nil {

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -29,7 +29,8 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 
 	startTime := time.Now()
 
-	image, err := docker.GetBuilderImage(client, config)
+	dkr := docker.New(client, config.PullAuthentication)
+	image, err := docker.GetBuilderImage(dkr, config)
 	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullBuilderImage, startTime, time.Now())
 	if err != nil {
 		buildInfo.FailureReason = utilstatus.NewFailureReason(
@@ -40,7 +41,7 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 	}
 	config.HasOnBuild = image.OnBuild
 
-	if config.AssembleUser, err = docker.GetAssembleUser(client, config); err != nil {
+	if config.AssembleUser, err = docker.GetAssembleUser(dkr, config); err != nil {
 		buildInfo.FailureReason = utilstatus.NewFailureReason(
 			utilstatus.ReasonPullBuilderImageFailed,
 			utilstatus.ReasonMessagePullBuilderImageFailed,

--- a/pkg/cmd/cli/cmd/rebuild.go
+++ b/pkg/cmd/cli/cmd/rebuild.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/api/describe"
@@ -46,8 +47,8 @@ func NewCmdRebuild(cfg *api.Config) *cobra.Command {
 
 			client, err := docker.NewEngineAPIClient(cfg.DockerConfig)
 			s2ierr.CheckError(err)
-
-			pr, err := docker.GetRebuildImage(client, cfg)
+			dkr := docker.New(client, cfg.PullAuthentication)
+			pr, err := docker.GetRebuildImage(dkr, cfg)
 			s2ierr.CheckError(err)
 			err = build.GenerateConfigFromLabels(cfg, pr)
 			s2ierr.CheckError(err)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -233,7 +233,27 @@ func NewUserNotAllowedError(image string, onbuild bool) error {
 	return Error{
 		Message:    msg,
 		ErrorCode:  UserNotAllowedError,
-		Suggestion: fmt.Sprintf("modify image %q to use a numeric user within the allowed range or build without the --allowed-uids flag", image),
+		Suggestion: fmt.Sprintf("modify image %q to use a numeric user within the allowed range, or build without the --allowed-uids flag", image),
+	}
+}
+
+// NewAssembleUserNotAllowedError returns a new error that indicates that the build
+// could not run because the build or image uses an assemble user outside of the range
+// of allowed users.
+func NewAssembleUserNotAllowedError(image string, usesConfig bool) error {
+	var msg, suggestion string
+	if usesConfig {
+		msg = "assemble user must be numeric and within the range of allowed users"
+		suggestion = "build without the allowed-uids or assemble-user configurations set"
+	} else {
+		assembleLabel := "io.openshift.s2i.assemble-user"
+		msg = fmt.Sprintf("image %q includes the %q label whose value is not within the allowed range", image, assembleLabel)
+		suggestion = fmt.Sprintf("modify the %q label in image %q to use a numeric user within the allowed range, or build without the allowed-uids configuration set", assembleLabel, image)
+	}
+	return Error{
+		Message:    msg,
+		ErrorCode:  UserNotAllowedError,
+		Suggestion: suggestion,
 	}
 }
 

--- a/test/integration/images/sti-fake-assemble-root/Dockerfile
+++ b/test/integration/images/sti-fake-assemble-root/Dockerfile
@@ -1,0 +1,12 @@
+#
+# This is fake image used for testing STI. It tests running build with the root assemble user
+#
+FROM sti_test/sti-fake
+
+LABEL io.openshift.s2i.assemble-user="0"
+
+RUN mkdir -p /sti-fake && \
+    adduser -u 431 -h /sti-fake -s /sbin/nologin -D fakeuser && \
+    chown -R fakeuser /sti-fake
+
+USER 431

--- a/test/integration/images/sti-fake-assemble-user/Dockerfile
+++ b/test/integration/images/sti-fake-assemble-user/Dockerfile
@@ -1,0 +1,12 @@
+#
+# This is fake image used for testing STI. It tests running build with an assemble user
+#
+FROM sti_test/sti-fake
+
+LABEL io.openshift.s2i.assemble-user="431"
+
+RUN mkdir -p /sti-fake && \
+    adduser -u 431 -h /sti-fake -s /sbin/nologin -D fakeuser && \
+    chown -R fakeuser /sti-fake
+
+USER 431

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -44,6 +44,8 @@ const (
 	FakeNumericUserImage            = "sti_test/sti-fake-numericuser"
 	FakeImageOnBuildRootUser        = "sti_test/sti-fake-onbuild-rootuser"
 	FakeImageOnBuildNumericUser     = "sti_test/sti-fake-onbuild-numericuser"
+	FakeImageAssembleRoot           = "sti_test/sti-fake-assemble-root"
+	FakeImageAssembleUser           = "sti_test/sti-fake-assemble-user"
 
 	TagCleanBuild                              = "test/sti-fake-app"
 	TagCleanBuildUser                          = "test/sti-fake-app-user"
@@ -62,6 +64,8 @@ const (
 	TagCleanBuildAllowedUIDsNumericUser        = "test/sti-fake-alloweduids-numericuser"
 	TagCleanBuildAllowedUIDsOnBuildRoot        = "test/sti-fake-alloweduids-onbuildroot"
 	TagCleanBuildAllowedUIDsOnBuildNumericUser = "test/sti-fake-alloweduids-onbuildnumeric"
+	TagCleanBuildAllowedUIDsAssembleRoot       = "test/sti-fake-alloweduids-assembleroot"
+	TagCleanBuildAllowedUIDsAssembleUser       = "test/sti-fake-alloweduids-assembleuser"
 
 	// Need to serve the scripts from local host so any potential changes to the
 	// scripts are made available for integration testing.
@@ -254,6 +258,14 @@ func TestAllowedUIDsOnBuildRootUser(t *testing.T) {
 
 func TestAllowedUIDsOnBuildNumericUser(t *testing.T) {
 	integration(t).exerciseCleanAllowedUIDsBuild(TagCleanBuildAllowedUIDsNumericUser, FakeImageOnBuildNumericUser, false)
+}
+
+func TestAllowedUIDsAssembleRoot(t *testing.T) {
+	integration(t).exerciseCleanAllowedUIDsBuild(TagCleanBuildAllowedUIDsAssembleRoot, FakeImageAssembleRoot, true)
+}
+
+func TestAllowedUIDsAssembleUser(t *testing.T) {
+	integration(t).exerciseCleanAllowedUIDsBuild(TagCleanBuildAllowedUIDsAssembleUser, FakeImageAssembleUser, false)
 }
 
 func (i *integrationTest) exerciseCleanAllowedUIDsBuild(tag, imageName string, expectError bool) {


### PR DESCRIPTION
Adding check to ensure the s2i assemble user is allowed if the --allowed-uids flag is set.
The assemble user can come from one of two sources:

1. --assemble-user flag
2. Builder image io.openshift.s2i.assemble-user label.

The assemble user overrides the default image user for an s2i build.
However, if the base image has ONBUILD instructions with USER directives,
all USER directives will be checked to ensure compliance.

Bug 1582976

Backport of #879 to origin 3.9

/assign @csrwng 
/cc @bparees @gabemontero 