### PR TITLE
[3.9] prevent save-artifact tar extraction from overwriting files out…

### DIFF
--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -109,7 +109,7 @@ func New(client dockerpkg.Client, config *api.Config, fs fs.FileSystem, override
 		config.PullAuthentication,
 		fs,
 	)
-	tarHandler := tar.New(fs)
+	tarHandler := tar.NewParanoid(fs)
 	tarHandler.SetExclusionPattern(excludePattern)
 
 	builder := &STI{


### PR DESCRIPTION
…side the working dir

Backporting PR #870 to s2i 3.9 branch.

/assign @csrwng 
/cc @bparees 