### PR TITLE
Improve cross-platform compatibility in generated test script

### DIFF
--- a/examples/nginx-centos7/test/run
+++ b/examples/nginx-centos7/test/run
@@ -12,17 +12,20 @@
 IMAGE_NAME=${IMAGE_NAME-nginx-centos7-candidate}
 
 # Determining system utility executables (darwin compatibility check)
-READLINK_EXEC="readlink"
-MKTEMP_EXEC="mktemp"
+READLINK_EXEC="readlink -zf"
+MKTEMP_EXEC="mktemp --suffix=.cid"
 if [[ "$OSTYPE" =~ 'darwin' ]]; then
+  READLINK_EXEC="readlink"
+  MKTEMP_EXEC="mktemp"
   ! type -a "greadlink" &>"/dev/null" || READLINK_EXEC="greadlink"
   ! type -a "gmktemp" &>"/dev/null" || MKTEMP_EXEC="gmktemp"
 fi
 
-test_dir="$($READLINK_EXEC -zf $(dirname "${BASH_SOURCE[0]}"))"
-image_dir=$($READLINK_EXEC -zf ${test_dir}/..)
-scripts_url="file://${image_dir}/.s2i/bin"
-cid_file=$($MKTEMP_EXEC -u --suffix=.cid)
+_dir="$(dirname "${BASH_SOURCE[0]}")"
+test_dir="$($READLINK_EXEC ${_dir} || echo ${_dir})"
+image_dir=$($READLINK_EXEC ${test_dir}/.. || echo ${test_dir}/..)
+scripts_url="${image_dir}/.s2i/bin"
+cid_file=$($MKTEMP_EXEC -u)
 
 # Since we built the candidate image locally, we don't want S2I to attempt to pull
 # it from Docker hub
@@ -40,23 +43,15 @@ container_exists() {
 }
 
 container_ip() {
-  if [ ! -z "$DOCKER_HOST" ] && [[ "$OSTYPE" =~ 'darwin' ]]; then
-    docker-machine ip
-  else
-    docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
-  fi
+  docker inspect --format="{{(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostIp}}" "$(cat "${cid_file}")" | sed 's/0.0.0.0/localhost/'
 }
 
 container_port() {
-  if [ ! -z "$DOCKER_HOST" ] && [[ "$OSTYPE" =~ 'darwin' ]]; then
-    docker inspect --format="{{(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostPort}}" "$(cat "${cid_file}")"
-  else
-    echo $test_port
-  fi
+  docker inspect --format="{{(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostPort}}" "$(cat "${cid_file}")"
 }
 
 run_s2i_build() {
-  s2i build --incremental=true ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build --incremental=true ${s2i_args} ${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 prepare() {
@@ -74,7 +69,7 @@ prepare() {
 }
 
 run_test_application() {
-  docker run --rm --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp
+  docker run --rm --cidfile=${cid_file} -p ${test_port}:${test_port} ${IMAGE_NAME}-testapp
 }
 
 cleanup() {
@@ -157,4 +152,3 @@ test_connection
 check_result $?
 
 cleanup
-


### PR DESCRIPTION
This pull request contains some adjustments to the test/run script that is created when a new source-2-image project is bootstrapped using ```s2i create``` to make it work on both Linux and OSX. The nginx-centos7 example has been adjusted with the same changes. Additionally, it removes the "file://" uri which breaks the test as well.
