### PR TITLE
Fix Hang if Injected Dir Does Not Exist

### DIFF
--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -127,6 +127,20 @@ func CreateTruncateFilesScript(files []string, scriptName string) (string, error
 	return f.Name(), err
 }
 
+// CreateInjectionResultFile creates a result file with the message from the provided injection
+// error. The path to the result file is returned. If the provided error is nil, an empty file is
+// created.
+func CreateInjectionResultFile(injectErr error) (string, error) {
+	f, err := ioutil.TempFile("", "s2i-injection-result")
+	if err != nil {
+		return "", err
+	}
+	if injectErr != nil {
+		err = ioutil.WriteFile(f.Name(), []byte(injectErr.Error()), 0700)
+	}
+	return f.Name(), err
+}
+
 // HandleInjectionError handles the error caused by injection and provide
 // reasonable suggestion to users.
 func HandleInjectionError(p api.VolumeSpec, err error) error {


### PR DESCRIPTION
- Added a "response file" to report failed injections on s2i
container
- Fixed assemble command to ensure s2i container exits if
injection fails

OpenShift bug [1608714](https://bugzilla.redhat.com/show_bug.cgi?id=1608714)