### PR TITLE
Update example repos that were moved to sclorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a deep dive on S2I you can view [this presentation](https://www.youtube.com/
 
 Want to try it right now?  Download the [latest release](https://github.com/openshift/source-to-image/releases/latest) and run:
 
-	$ s2i build https://github.com/openshift/django-ex centos/python-35-centos7 hello-python
+	$ s2i build https://github.com/sclorg/django-ex centos/python-35-centos7 hello-python
 	$ docker run -p 8080:8080 hello-python
 
 Now browse to http://localhost:8080 to see the running application.

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -74,7 +74,7 @@ pushd ${WORK_DIR}
 
 test_debug "cloning source into working dir"
 
-git clone https://github.com/openshift/cakephp-ex &> "${WORK_DIR}/s2i-git-clone.log"
+git clone https://github.com/sclorg/cakephp-ex &> "${WORK_DIR}/s2i-git-clone.log"
 check_result $? "${WORK_DIR}/s2i-git-clone.log"
 
 test_debug "s2i build with relative path without file://"
@@ -137,7 +137,7 @@ grep "Running custom run" "${WORK_DIR}/s2i-override-run.log"
 check_result $? "${WORK_DIR}/s2i-override-run.log"
 
 test_debug "s2i build with remote git repo"
-s2i build https://github.com/openshift/cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
+s2i build https://github.com/sclorg/cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
 check_result $? "${WORK_DIR}/s2i-git-proto.log"
 
 test_debug "s2i build with runtime image"
@@ -145,7 +145,7 @@ s2i build --ref=10.x --context-dir=helloworld https://github.com/wildfly/quickst
 check_result $? "${WORK_DIR}/s2i-runtime-image.log"
 
 test_debug "s2i build with Dockerfile output"
-s2i build https://github.com/openshift/cakephp-ex docker.io/centos/php-70-centos7 --as-dockerfile=${WORK_DIR}/asdockerfile/Dockerfile --loglevel=5 >& "${WORK_DIR}/s2i-dockerfile.log"
+s2i build https://github.com/sclorg/cakephp-ex docker.io/centos/php-70-centos7 --as-dockerfile=${WORK_DIR}/asdockerfile/Dockerfile --loglevel=5 >& "${WORK_DIR}/s2i-dockerfile.log"
 check_result $? "${WORK_DIR}/s2i-dockerfile.log"
 
 


### PR DESCRIPTION
github.com/openshift/django-ex has been moved to github.com/sclorg/django-ex
github.com/openshift/cakephp-ex has been moved to github.com/sclorg/cakephp-ex