### PR TITLE
add add-hosts

### DIFF
--- a/contrib/completions/bash/s2i
+++ b/contrib/completions/bash/s2i
@@ -234,6 +234,8 @@ _s2i_build()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--add-host=")
+    local_nonpersistent_flags+=("--add-host=")
     flags+=("--allowed-uids=")
     two_word_flags+=("-u")
     local_nonpersistent_flags+=("--allowed-uids=")

--- a/contrib/completions/zsh/s2i
+++ b/contrib/completions/zsh/s2i
@@ -395,6 +395,8 @@ _s2i_build()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--add-host=")
+    local_nonpersistent_flags+=("--add-host=")
     flags+=("--allowed-uids=")
     two_word_flags+=("-u")
     local_nonpersistent_flags+=("--allowed-uids=")

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -136,6 +136,12 @@ docker run test >& "${WORK_DIR}/s2i-override-run.log"
 grep "Running custom run" "${WORK_DIR}/s2i-override-run.log"
 check_result $? "${WORK_DIR}/s2i-override-run.log"
 
+test_debug "s2i build with add-host option"
+set +e
+s2i build https://github.com/openshift/ruby-hello-world centos/ruby-23-centos7 --add-host rubygems.org:0.0.0.0 test-ruby-app &> "${WORK_DIR}/s2i-add-host.log"
+grep "Gem::RemoteFetcher::FetchError: Errno::ECONNREFUSED" "${WORK_DIR}/s2i-add-host.log"
+check_result $? "${WORK_DIR}/s2i-add-host.log"
+set -e
 test_debug "s2i build with remote git repo"
 s2i build https://github.com/sclorg/cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
 check_result $? "${WORK_DIR}/s2i-git-proto.log"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -247,6 +247,8 @@ type Config struct {
 	// ImageScriptsURL is the default location to find the assemble/run scripts for a builder image.
 	// This url can be a reference within the builder image if the scheme is specified as image://
 	ImageScriptsURL string
+	// AddHost Add a line to /etc/hosts for test purpose or private use in LAN. Its format is host:IP,muliple hosts can be added  by using multiple --add-host
+	AddHost []string
 }
 
 // EnvironmentSpec specifies a single environment variable.

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -547,6 +547,7 @@ func (builder *STI) Save(config *api.Config) (err error) {
 		CapDrop:         config.DropCapabilities,
 		Binds:           config.BuildVolumes,
 		SecurityOpt:     config.SecurityOpt,
+		AddHost:         config.AddHost,
 	}
 
 	dockerpkg.StreamContainerIO(errReader, nil, func(s string) { glog.Info(s) })
@@ -605,6 +606,7 @@ func (builder *STI) Execute(command string, user string, config *api.Config) err
 		CapDrop:         config.DropCapabilities,
 		Binds:           config.BuildVolumes,
 		SecurityOpt:     config.SecurityOpt,
+		AddHost:         config.AddHost,
 	}
 
 	// If there are injections specified, override the original assemble script

--- a/pkg/cmd/cli/cmd/build.go
+++ b/pkg/cmd/cli/cmd/build.go
@@ -215,5 +215,6 @@ $ s2i build . centos/ruby-22-centos7 hello-world-app
 	buildCmd.Flags().StringVar(&(networkMode), "network", "", "Specify the default Docker Network name to be used in build process")
 	buildCmd.Flags().StringVarP(&(cfg.AsDockerfile), "as-dockerfile", "", "", "EXPERIMENTAL: Output a Dockerfile to this path instead of building a new image")
 	buildCmd.Flags().BoolVarP(&(cfg.KeepSymlinks), "keep-symlinks", "", false, "When using '--copy', copy symlinks as symlinks. Default behavior is to follow symlinks and copy files by content")
+	buildCmd.Flags().StringArrayVar(&cfg.AddHost, "add-host", []string{}, "Specify additional entries to add to the /etc/hosts in the assemble container, multiple --add-host can be used to add multiple entries")
 	return buildCmd
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -169,6 +169,7 @@ type RunContainerOptions struct {
 	ScriptsURL      string
 	Destination     string
 	Env             []string
+	AddHost         []string
 	// Entrypoint will be used to override the default entrypoint
 	// for the image if it has one.  If the image has no entrypoint,
 	// this value is ignored.
@@ -221,6 +222,7 @@ func (rco RunContainerOptions) asDockerHostConfig() dockercontainer.HostConfig {
 		PublishAllPorts: rco.TargetImage,
 		NetworkMode:     dockercontainer.NetworkMode(rco.NetworkMode),
 		Binds:           rco.Binds,
+		ExtraHosts:      rco.AddHost,
 		SecurityOpt:     rco.SecurityOpt,
 	}
 	if rco.CGroupLimits != nil {


### PR DESCRIPTION
Add a `--add-host` flag，same as `--add-host` in `docker run` . It is very useful when user in LAN or in dev environment.