### PR TITLE
dockerfile - Report Error if No Scripts Install

### DIFF
--- a/pkg/build/strategies/dockerfile/dockerfile_test.go
+++ b/pkg/build/strategies/dockerfile/dockerfile_test.go
@@ -1,9 +1,15 @@
 package dockerfile
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/api/constants"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 func TestGetImageScriptsDir(t *testing.T) {
@@ -68,4 +74,133 @@ func TestGetImageScriptsDir(t *testing.T) {
 			t.Errorf("Expected has all scripts indicator:\n%v\nto be: %v", hasScripts, tc.HasAllScripts)
 		}
 	}
+}
+
+func TestInstallScripts(t *testing.T) {
+	allErrs := map[string]bool{
+		constants.Assemble:      true,
+		constants.Run:           true,
+		constants.SaveArtifacts: true,
+	}
+
+	tests := []struct {
+		name                string
+		url                 string
+		createAssemble      bool
+		createRun           bool
+		createSaveArtifacts bool
+		scriptErrs          map[string]bool
+	}{
+		{
+			name:       "empty",
+			scriptErrs: allErrs,
+		},
+		{
+			name:       "bad url",
+			url:        "https://foobadbar.com",
+			scriptErrs: allErrs,
+		},
+		{
+			// image:// URLs should always report success
+			name: "image url",
+			url:  "image://path/to/scripts",
+		},
+		{
+			name:           "assemble script",
+			createAssemble: true,
+			scriptErrs: map[string]bool{
+				constants.Assemble:      false,
+				constants.Run:           true,
+				constants.SaveArtifacts: true,
+			},
+		},
+		{
+			name:      "run script",
+			createRun: true,
+			scriptErrs: map[string]bool{
+				constants.Assemble:      true,
+				constants.Run:           false,
+				constants.SaveArtifacts: true,
+			},
+		},
+		{
+			name:                "save-artifacts script",
+			createSaveArtifacts: true,
+			scriptErrs: map[string]bool{
+				constants.Assemble:      true,
+				constants.Run:           true,
+				constants.SaveArtifacts: false,
+			},
+		},
+		{
+			name:                "all scripts",
+			createAssemble:      true,
+			createRun:           true,
+			createSaveArtifacts: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir, err := ioutil.TempDir("", "s2i-dockerfile-uploads")
+			if err != nil {
+				t.Fatalf("failed to create working dir: %v", err)
+			}
+			defer os.RemoveAll(workDir)
+			config := &api.Config{
+				WorkingDir: workDir,
+			}
+			fileSystem := fs.NewFileSystem()
+			for _, v := range workingDirs {
+				err = fileSystem.MkdirAllWithPermissions(filepath.Join(workDir, v), 0755)
+				if err != nil {
+					t.Fatalf("failed to create working dir: %v", err)
+				}
+			}
+
+			tempDir, err := ioutil.TempDir("", "s2i-dockerfile-scripts")
+			if err != nil {
+				t.Fatalf("could not create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+			if tc.createAssemble {
+				err := createTestScript(tempDir, constants.Assemble)
+				if err != nil {
+					t.Fatalf("failed to write %s script: %v", constants.Assemble, err)
+				}
+				tc.url = fmt.Sprintf("file://%s", filepath.ToSlash(tempDir))
+			}
+			if tc.createRun {
+				err := createTestScript(tempDir, constants.Run)
+				if err != nil {
+					t.Fatalf("failed to write %s script: %v", constants.Run, err)
+				}
+				tc.url = fmt.Sprintf("file://%s", filepath.ToSlash(tempDir))
+			}
+			if tc.createSaveArtifacts {
+				err := createTestScript(tempDir, constants.SaveArtifacts)
+				if err != nil {
+					t.Fatalf("failed to write %s script: %v", constants.SaveArtifacts, err)
+				}
+				tc.url = fmt.Sprintf("file://%s", filepath.ToSlash(tempDir))
+			}
+			builder, _ := New(config, fileSystem)
+			results := builder.installScripts(tc.url, config)
+			for _, script := range results {
+				expectErr := tc.scriptErrs[script.Script]
+				if expectErr && script.Error == nil {
+					t.Errorf("expected error for %s, got nil", script.Script)
+				}
+				if script.Error != nil && !expectErr {
+					t.Errorf("received unexpected error: %v", script.Error)
+				}
+			}
+		})
+	}
+}
+
+func createTestScript(dir string, name string) error {
+	script := "echo \"test script\""
+	path := filepath.Join(dir, name)
+	err := ioutil.WriteFile(path, []byte(script), 0700)
+	return err
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -625,7 +625,7 @@ func TestDockerfileBuild(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "MyDockerfile"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
@@ -667,7 +667,7 @@ func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "Dockerfile"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildEnv(t *testing.T) {
@@ -705,7 +705,7 @@ func TestDockerfileBuildEnv(t *testing.T) {
 		"key1=\"value1\"",
 		"key2=\"value2\"",
 	}
-	runDockerfileTest(t, config, expected, nil, nil)
+	runDockerfileTest(t, config, expected, nil, nil, false)
 }
 
 func TestDockerfileBuildLabels(t *testing.T) {
@@ -742,7 +742,7 @@ func TestDockerfileBuildLabels(t *testing.T) {
 		"\"label1\"=\"value1\"",
 		"\"label2\"=\"value2\"",
 	}
-	runDockerfileTest(t, config, expected, nil, nil)
+	runDockerfileTest(t, config, expected, nil, nil, false)
 }
 
 func TestDockerfileBuildInjections(t *testing.T) {
@@ -822,7 +822,7 @@ func TestDockerfileBuildInjections(t *testing.T) {
 		filepath.Join(tempdir, "upload/injections"+trimmedInjection1),
 		filepath.Join(tempdir, "upload/injections"+trimmedInjection2),
 	}
-	runDockerfileTest(t, config, expected, notExpected, expectedFiles)
+	runDockerfileTest(t, config, expected, notExpected, expectedFiles, false)
 }
 
 func TestDockerfileBuildScriptsURLAssemble(t *testing.T) {
@@ -862,7 +862,7 @@ func TestDockerfileBuildScriptsURLAssemble(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildScriptsURLRun(t *testing.T) {
@@ -902,7 +902,31 @@ func TestDockerfileBuildScriptsURLRun(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "upload/scripts/run"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
+}
+
+func TestDockerfileBuildScriptsURLNone(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	if err != nil {
+		t.Errorf("Unable to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempdir)
+
+	config := &api.Config{
+		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		AssembleUser: "",
+		ImageWorkDir: "",
+		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
+		ScriptsURL:   "file://" + filepath.ToSlash(tempdir),
+		Injections:   api.VolumeList{},
+		Destination:  "/destination",
+
+		Environment: api.EnvironmentList{},
+		Labels:      map[string]string{},
+
+		AsDockerfile: filepath.Join(tempdir, "Dockerfile"),
+	}
+	runDockerfileTest(t, config, nil, nil, nil, true)
 }
 
 func TestDockerfileBuildSourceScriptsAssemble(t *testing.T) {
@@ -949,7 +973,7 @@ func TestDockerfileBuildSourceScriptsAssemble(t *testing.T) {
 	expectedFiles := []string{
 		filepath.Join(tempdir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildSourceScriptsRun(t *testing.T) {
@@ -996,7 +1020,7 @@ func TestDockerfileBuildSourceScriptsRun(t *testing.T) {
 	expectedFiles := []string{
 		filepath.Join(tempdir, "upload/scripts/run"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 // TestDockerfileBuildScriptsURLImage tests the behavior if the ScriptsURL
@@ -1047,7 +1071,7 @@ func TestDockerfileBuildScriptsURLImage(t *testing.T) {
 		"(?m)^RUN chown -R 1001:0.* /destination/scripts",
 		"(?m)^RUN /destination/scripts/assemble",
 	}
-	runDockerfileTest(t, config, expected, notExpected, nil)
+	runDockerfileTest(t, config, expected, notExpected, nil, false)
 }
 
 func TestDockerfileBuildImageScriptsURLAssemble(t *testing.T) {
@@ -1087,7 +1111,7 @@ func TestDockerfileBuildImageScriptsURLAssemble(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildImageScriptsURLRun(t *testing.T) {
@@ -1127,7 +1151,7 @@ func TestDockerfileBuildImageScriptsURLRun(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "upload/scripts/run"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildImageScriptsURLImage(t *testing.T) {
@@ -1174,7 +1198,7 @@ func TestDockerfileBuildImageScriptsURLImage(t *testing.T) {
 	expectedFiles := []string{
 		filepath.Join(tempdir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileBuildScriptsAndImageURL(t *testing.T) {
@@ -1215,7 +1239,7 @@ func TestDockerfileBuildScriptsAndImageURL(t *testing.T) {
 		filepath.Join(tempdir, "upload/src/server.js"),
 		filepath.Join(tempdir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 // TestDockerfileBuildScriptsAndImageURLConflicts tests if both
@@ -1278,7 +1302,7 @@ func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
 		filepath.Join(outputDir, "upload/src/server.js"),
 		filepath.Join(outputDir, "upload/scripts/assemble"),
 	}
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 	dockerfileAssemble, err := ioutil.ReadFile(filepath.Join(outputDir, "upload/scripts/assemble"))
 	if err != nil {
 		t.Errorf("Failed to read uploaded assemble script: %v", err)
@@ -1326,7 +1350,7 @@ func TestDockerfileIncrementalBuild(t *testing.T) {
 		"(?m)^CMD /usr/libexec/s2i/run",
 	}
 
-	runDockerfileTest(t, config, expected, nil, nil)
+	runDockerfileTest(t, config, expected, nil, nil, false)
 }
 
 func TestDockerfileIncrementalSourceSave(t *testing.T) {
@@ -1381,7 +1405,7 @@ func TestDockerfileIncrementalSourceSave(t *testing.T) {
 		filepath.Join(tempdir, "upload/scripts/save-artifacts"),
 	}
 
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileIncrementalSaveURL(t *testing.T) {
@@ -1429,7 +1453,7 @@ func TestDockerfileIncrementalSaveURL(t *testing.T) {
 		filepath.Join(tempdir, "upload/scripts/save-artifacts"),
 	}
 
-	runDockerfileTest(t, config, expected, nil, expectedFiles)
+	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
 }
 
 func TestDockerfileIncrementalTag(t *testing.T) {
@@ -1465,7 +1489,7 @@ func TestDockerfileIncrementalTag(t *testing.T) {
 		"(?m)^CMD /usr/libexec/s2i/run",
 	}
 
-	runDockerfileTest(t, config, expected, nil, nil)
+	runDockerfileTest(t, config, expected, nil, nil, false)
 }
 
 func TestDockerfileIncrementalAssembleUser(t *testing.T) {
@@ -1501,20 +1525,27 @@ func TestDockerfileIncrementalAssembleUser(t *testing.T) {
 		"(?m)^CMD /usr/libexec/s2i/run",
 	}
 
-	runDockerfileTest(t, config, expected, nil, nil)
+	runDockerfileTest(t, config, expected, nil, nil, false)
 }
 
-func runDockerfileTest(t *testing.T, config *api.Config, expected []string, notExpected []string, expectedFiles []string) {
+func runDockerfileTest(t *testing.T, config *api.Config, expected []string, notExpected []string, expectedFiles []string, expectFailure bool) {
 
 	b, _, err := strategies.GetStrategy(nil, config)
 	if err != nil {
 		t.Fatalf("Cannot create a new builder.")
 	}
 	resp, err := b.Build(config)
+	if expectFailure {
+		if err == nil || resp.Success {
+			t.Errorf("The build succeded when it should have failed. Success: %t, error: %v", resp.Success, err)
+		}
+		return
+	}
 	if err != nil {
 		t.Fatalf("An error occurred during the build: %v", err)
-	} else if !resp.Success {
-		t.Fatalf("The build failed.")
+	}
+	if !resp.Success {
+		t.Fatalf("The build failed when it should have succeeded.")
 	}
 
 	filebytes, err := ioutil.ReadFile(config.AsDockerfile)


### PR DESCRIPTION
* Raise an error if no scripts are downloaded from the ScriptsURL
* Update unit and integration tests to check for raised errors

Fixes [bug 1668130](https://bugzilla.redhat.com/show_bug.cgi?id=1668130)