### PR TITLE
remove basename in main(), the var basename is not used in func CommandFor()

### DIFF
--- a/cmd/s2i/s2i.go
+++ b/cmd/s2i/s2i.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -17,8 +16,7 @@ func main() {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 
-	basename := filepath.Base(os.Args[0])
-	command := cli.CommandFor(basename)
+	command := cli.CommandFor()
 	if err := command.Execute(); err != nil {
 		fmt.Println(fmt.Sprintf("S2I encountered the following error: %v", err))
 		os.Exit(1)

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -66,6 +66,6 @@ func NewCmdCLI() *cobra.Command {
 
 // CommandFor returns the appropriate command for this base name,
 // or the OpenShift CLI command.
-func CommandFor(basename string) *cobra.Command {
+func CommandFor() *cobra.Command {
 	return NewCmdCLI()
 }


### PR DESCRIPTION
Signed-off-by: soulseen <sunzhu@yunify.com>