### PR TITLE
Honor builder image labels when --as-dockerfile is enabled

### DIFF
--- a/pkg/api/describe/describer.go
+++ b/pkg/api/describe/describer.go
@@ -108,7 +108,7 @@ func describeBuilderImage(client docker.Client, config *api.Config, out io.Write
 	dkr := docker.New(client, c.PullAuthentication)
 	builderImage, err := docker.GetBuilderImage(dkr, c)
 	if err == nil {
-		build.GenerateConfigFromLabels(c, builderImage)
+		build.GenerateConfigFromApplicationImageLabels(c, builderImage)
 		if len(c.DisplayName) > 0 {
 			fmt.Fprintf(out, "Builder Name:\t%s\n", c.DisplayName)
 		}

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -12,12 +12,12 @@ import (
 
 // GenerateConfigFromLabels generates the S2I Config struct from the Docker
 // image labels.
-func GenerateConfigFromLabels(config *api.Config, metadata *docker.PullResult) error {
+func GenerateConfigFromApplicationImageLabels(config *api.Config, metadata *docker.PullResult) error {
 	if config == nil {
-		return errors.New("config must be provided to GenerateConfigFromLabels")
+		return errors.New("config must be provided to GenerateConfigFromApplicationImageLabels")
 	}
 	if metadata == nil {
-		return errors.New("image metadata must be provided to GenerateConfigFromLabels")
+		return errors.New("image metadata must be provided to GenerateConfigFromApplicationImageLabels")
 	}
 
 	labels := metadata.Image.Config.Labels

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -10,7 +10,20 @@ import (
 	"github.com/openshift/source-to-image/pkg/scm/git"
 )
 
-// GenerateConfigFromLabels generates the S2I Config struct from the Docker
+// GenerateConfigFromBuilderImageLabels generates the S@I Config struct from the Docker
+// image labels.
+func GenerateConfigFromBuilderImageLabels(config *api.Config, metadata *docker.PullResult) error {
+	if config == nil {
+		return errors.New("config must be provided to GenerateConfigFromBuilderImageLabels")
+	}
+	if metadata == nil {
+		return errors.New("image metadata must be provided to GenerateConfigFromBuilderImageLabels")
+	}
+
+	return nil
+}
+
+// GenerateConfigFromApplicationImageLabels generates the S2I Config struct from the Docker
 // image labels.
 func GenerateConfigFromApplicationImageLabels(config *api.Config, metadata *docker.PullResult) error {
 	if config == nil {

--- a/pkg/build/strategies/strategies.go
+++ b/pkg/build/strategies/strategies.go
@@ -48,6 +48,15 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 	}
 	config.HasOnBuild = image.OnBuild
 
+	err = build.GenerateConfigFromBuilderImageLabels(config, image)
+	if err != nil {
+		buildInfo.FailureReason = utilstatus.NewFailureReason(
+			utilstatus.ReasonGenerateConfigFromBuilderImageLabelsFailed,
+			utilstatus.ReasonMessageGenerateConfigFromBuilderImageLabelsFailed,
+		)
+		return nil, buildInfo, err
+	}
+
 	if config.AssembleUser, err = docker.GetAssembleUser(dkr, config); err != nil {
 		buildInfo.FailureReason = utilstatus.NewFailureReason(
 			utilstatus.ReasonPullBuilderImageFailed,

--- a/pkg/cmd/cli/cmd/rebuild.go
+++ b/pkg/cmd/cli/cmd/rebuild.go
@@ -50,7 +50,7 @@ func NewCmdRebuild(cfg *api.Config) *cobra.Command {
 			dkr := docker.New(client, cfg.PullAuthentication)
 			pr, err := docker.GetRebuildImage(dkr, cfg)
 			s2ierr.CheckError(err)
-			err = build.GenerateConfigFromLabels(cfg, pr)
+			err = build.GenerateConfigFromApplicationImageLabels(cfg, pr)
 			s2ierr.CheckError(err)
 
 			if len(args) >= 2 {

--- a/pkg/util/status/build_status.go
+++ b/pkg/util/status/build_status.go
@@ -12,6 +12,13 @@ const (
 	// script failing.
 	ReasonMessageAssembleFailed api.StepFailureMessage = "Assemble script failed."
 
+	// ReasonGenerateConfigFromBuilderImageLabelsFailed is the reason associated with the
+	// extraction of configuration from builder image labels failing.
+	ReasonGenerateConfigFromBuilderImageLabelsFailed api.StepFailureReason = "GenerateConfigFromBuilderImageLabelsFailed"
+	// ReasonMessageGenerateConfigFromBuilderImageLabelsFailed is the message associated with
+	// the extraction of configuration from builder image labels failing.
+	ReasonMessageGenerateConfigFromBuilderImageLabelsFailed api.StepFailureMessage = "Generate configuration from builder image labels failed."
+
 	// ReasonPullBuilderImageFailed is the reason associated with failing to pull
 	// the builder image.
 	ReasonPullBuilderImageFailed api.StepFailureReason = "PullBuilderImageFailed"


### PR DESCRIPTION
This PR consults the builder image labels to compose the resulting Dockerfile.

Similar to what happens in the `rebuild` command, the builder image metadata will be read and relevant labels will be used when composing the resulting Dockerfile.

If `--as-dockerfile` is expected to be used in environments where a Docker socket is not available, then this PR might break that expectation.