### PR TITLE
update restore-artifacts script

### DIFF
--- a/pkg/create/templates/scripts.go
+++ b/pkg/create/templates/scripts.go
@@ -19,7 +19,9 @@ fi
 #
 if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
   echo "---> Restoring build artifacts..."
+  shopt -s dotglob
   mv /tmp/artifacts/* ./
+  shopt -u dotglob
 fi
 
 echo "---> Installing application source..."

--- a/pkg/create/templates/scripts.go
+++ b/pkg/create/templates/scripts.go
@@ -19,7 +19,7 @@ fi
 #
 if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
   echo "---> Restoring build artifacts..."
-  mv /tmp/artifacts/. ./
+  mv /tmp/artifacts/* ./
 fi
 
 echo "---> Installing application source..."


### PR DESCRIPTION
Hi,

When testing the code in the example 'assemble' script, the syntax didn't seem to work:

```
mv /tmp/artifacts/. ./
```
resulted in the error

```
mv: cannot move '/tmp/artifacts/.' to './.': Device or resource busy
```
Actually, I would have expected it to be:

```
mv /tmp/artifacts/* ./
```

Any thoughts on this?  Could you reproduce the error? 

A more thorough modification would be the following. This catches hidden files also.   

```
shopt -s dotglob
mv /tmp/artifacts/* ./
shopt -u dotglob
```
