### PR TITLE
Update documentation for generate and --as-dockerfile

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -237,6 +237,13 @@ Usage:
 $ s2i generate <builder image> <output file>
 ```
 
+#### Example usage
+
+Generate a Dockerfile for the `centos/nodejs-10-centos7` builder image:
+```
+$ s2i generate docker://docker.io/centos/nodejs-10-centos7 Dockerfile.gen
+```
+
 # s2i usage
 
 The `s2i usage` command starts a container and runs the `usage` script which prints

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,7 @@ following sections of this document:
 * [create](#s2i-create)
 * [build](#s2i-build)
 * [rebuild](#s2i-rebuild)
+* [generate](#s2i-generate)
 * [usage](#s2i-usage)
 * [version](#s2i-version)
 * [help](#s2i-help)
@@ -218,6 +219,19 @@ Usage:
 $ s2i rebuild <image name> [<new-tag-name>]
 ```
 
+# s2i generate
+The `s2i generate` command produces a Dockerfile using an existing S2I base 
+image that can be used to produce an image by any application supporting the
+format.
+
+The *image name* argument is in the URL-like, for example 
+`docker://docker.io/centos/nodejs-10-centos7`.
+
+Usage:
+
+```
+$ s2i generate <image name> <output file>
+```
 
 # s2i usage
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,13 +228,13 @@ The `s2i generate` command generates a Dockerfile using an existing S2I builder
 image that can be used to produce an image by any application supporting the
 format.
 
-The *image name* argument is in the URL-like, for example 
-`docker://docker.io/centos/nodejs-10-centos7`.
+The *builder name* is a reference to the builder image that serves as the base 
+of the generated Dockerfile. For example, 
+`docker://docker.io/centos/nodejs-10-centos7:latest`.
 
 Usage:
-
 ```
-$ s2i generate <image name> <output file>
+$ s2i generate <builder image> <output file>
 ```
 
 # s2i usage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,7 +220,11 @@ $ s2i rebuild <image name> [<new-tag-name>]
 ```
 
 # s2i generate
-The `s2i generate` command produces a Dockerfile using an existing S2I base 
+
+This command is a Technology Preview feature, and is subject to change or be 
+removed without notice in a future release.
+
+The `s2i generate` command generates a Dockerfile using an existing S2I builder 
 image that can be used to produce an image by any application supporting the
 format.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -230,7 +230,7 @@ format.
 
 The *builder name* is a reference to the builder image that serves as the base 
 of the generated Dockerfile. For example, 
-`docker://docker.io/centos/nodejs-10-centos7:latest`.
+`docker.io/centos/nodejs-10-centos7:latest`.
 
 Usage:
 ```
@@ -241,7 +241,7 @@ $ s2i generate <builder image> <output file>
 
 Generate a Dockerfile for the `centos/nodejs-10-centos7` builder image:
 ```
-$ s2i generate docker://docker.io/centos/nodejs-10-centos7 Dockerfile.gen
+$ s2i generate docker.io/centos/nodejs-10-centos7 Dockerfile.gen
 ```
 
 # s2i usage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ that image and add them to the tar streamed to the container into `/artifacts`.
 |:----------------------------|:--------------------------------------------------------| 
 | `-u (--allowed-uids)`       | Specify a range of allowed user ids for the builder and runtime images. Ranges can be bounded (`1-10001`) or unbounded (`1-`). |
 | `-n (--application-name`)   | Specify the display name for the application (default: output image name) |
-| `--as-dockerfile`           | EXPERIMENTAL: Output a Dockerfile to this path instead of building a new image |
+| `--as-dockerfile`           | Output a Dockerfile to this path instead of building a new image |
 | `--assemble-user`           | Specify the user to run assemble with |
 | `--assemble-runtime-user`   | Specify the user to run assemble-runtime with |
 | `--callback-url`            | URL to be invoked after a build (see [Callback URL](#callback-url)) |

--- a/hack/test-docker.sh
+++ b/hack/test-docker.sh
@@ -24,4 +24,4 @@ echo
 echo "Running docker integration tests ..."
 echo
 
-S2I_TIMEOUT="-timeout 600s" "${S2I_ROOT}/hack/test-go.sh" test/integration/docker -v -tags "integration" "${@:1}"
+S2I_BUILD_TAGS="integration" S2I_TIMEOUT="-timeout 600s" "${S2I_ROOT}/hack/test-go.sh" test/integration/docker -v "${@:1}"

--- a/hack/test-dockerfile.sh
+++ b/hack/test-dockerfile.sh
@@ -17,4 +17,4 @@ echo
 echo "Running dockerfile integration tests ..."
 echo
 
-S2I_TIMEOUT="-timeout 600s" "${S2I_ROOT}/hack/test-go.sh" test/integration/dockerfile -v -tags "integration" "${@:1}"
+S2I_BUILD_TAGS="integration" S2I_TIMEOUT="-timeout 600s" "${S2I_ROOT}/hack/test-go.sh" test/integration/dockerfile -v "${@:1}"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -28,6 +28,7 @@ find_test_dirs() {
 S2I_RACE=${S2I_RACE--race}
 S2I_COVER=${S2I_COVER--cover}
 S2I_TIMEOUT=${S2I_TIMEOUT--timeout 60s}
+S2I_BUILD_TAGS=""
 
 if [ "${1-}" != "" ]; then
   test_packages="$S2I_GO_PACKAGE/$1"
@@ -49,7 +50,7 @@ if [[ -n "${OUTPUT_COVERAGE}" ]]; then
     fi
     S2I_COVER_PROFILE="-coverprofile=${PROFILEPATH}"
 
-    go test $S2I_RACE $S2I_TIMEOUT $S2I_COVER "$S2I_COVER_PROFILE" "$test_package" "${@:2}"
+    go test -tags "$S2I_BUILD_TAGS exclude_graphdriver_devicemapper exclude_graphdriver_btrfs" $S2I_RACE $S2I_TIMEOUT $S2I_COVER "$S2I_COVER_PROFILE" "$test_package" "${@:2}"
   done
 
   echo 'mode: atomic' > ${OUTPUT_COVERAGE}/profiles.out
@@ -66,5 +67,5 @@ if [[ -n "${OUTPUT_COVERAGE}" ]]; then
   # remove ${OUTPUT_COVERAGE}/github.com
   rm -rf $OUTPUT_COVERAGE/${S2I_GO_PACKAGE%%/*}
 else
-  go test $S2I_RACE $S2I_TIMEOUT $S2I_COVER "${@:2}" $test_packages
+  go test -tags "$S2I_BUILD_TAGS exclude_graphdriver_devicemapper exclude_graphdriver_btrfs" $S2I_RACE $S2I_TIMEOUT $S2I_COVER "${@:2}" $test_packages
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -15,7 +15,7 @@ FAILURE=false
 test_dirs=$(s2i::util::find_files | cut -d '/' -f 1-2 | sort -u)
 for test_dir in $test_dirs
 do
-  if ! go vet $test_dir
+  if ! go vet -tags "exclude_graphdriver_devicemapper exclude_graphdriver_btrfs" $test_dir
   then
     FAILURE=true
   fi

--- a/pkg/cmd/cli/cmd/generate.go
+++ b/pkg/cmd/cli/cmd/generate.go
@@ -58,10 +58,12 @@ func adjustConfigWithImageLabels(cfg *api.Config, labels map[string]string) {
 // NewCmdGenerate implements the S2I cli generate command.
 func NewCmdGenerate(cfg *api.Config) *cobra.Command {
 	generateCmd := &cobra.Command{
-		Use:   "generate <image> <dockerfile>",
-		Short: "Generate a Dockerfile based on the provided builder image",
+		Use: "generate <image> <dockerfile>",
+		Short: "Generate a Dockerfile using an existing S2I builder	image " +
+			"that can be used to produce an image by any application " +
+			"supporting the format.",
 		Example: `
-# Generate a Dockerfile from a builder image:
+# Generate a Dockerfile for the centos/nodejs-10-centos7 builder image:
 $ s2i generate docker://docker.io/centos/nodejs-10-centos7 Dockerfile.gen
 `,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/pkg/cmd/cli/cmd/generate.go
+++ b/pkg/cmd/cli/cmd/generate.go
@@ -5,6 +5,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
+	"strings"
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/api/constants"
@@ -55,6 +56,14 @@ func adjustConfigWithImageLabels(cfg *api.Config, labels map[string]string) {
 
 }
 
+// CanonizeBuilderImageArg appends 'docker://' if the builder image doesn't contain the a schema.
+func CanonizeBuilderImageArg(builderImage string) string {
+	if strings.Contains(builderImage, "://") {
+		return builderImage
+	}
+	return "docker://" + builderImage
+}
+
 // NewCmdGenerate implements the S2I cli generate command.
 func NewCmdGenerate(cfg *api.Config) *cobra.Command {
 	generateCmd := &cobra.Command{
@@ -71,7 +80,9 @@ $ s2i generate docker://docker.io/centos/nodejs-10-centos7 Dockerfile.gen
 				return cmd.Help()
 			}
 
-			ref, err := alltransports.ParseImageName(cmd.Flags().Arg(0))
+			builderImageArg := CanonizeBuilderImageArg(cmd.Flags().Arg(0))
+
+			ref, err := alltransports.ParseImageName(builderImageArg)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cli/cmd/generate.go
+++ b/pkg/cmd/cli/cmd/generate.go
@@ -67,13 +67,13 @@ func CanonizeBuilderImageArg(builderImage string) string {
 // NewCmdGenerate implements the S2I cli generate command.
 func NewCmdGenerate(cfg *api.Config) *cobra.Command {
 	generateCmd := &cobra.Command{
-		Use: "generate <image> <dockerfile>",
+		Use: "generate <builder image> <output file>",
 		Short: "Generate a Dockerfile using an existing S2I builder	image " +
 			"that can be used to produce an image by any application " +
 			"supporting the format.",
 		Example: `
 # Generate a Dockerfile for the centos/nodejs-10-centos7 builder image:
-$ s2i generate docker://docker.io/centos/nodejs-10-centos7 Dockerfile.gen
+$ s2i generate docker.io/centos/nodejs-10-centos7 Dockerfile.gen
 `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cmd.Flags().NArg() != 2 {

--- a/test/generate_test.go
+++ b/test/generate_test.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"github.com/openshift/source-to-image/pkg/cmd/cli/cmd"
+	"testing"
+)
+
+func TestGenerate_canonizeBuilderImageArg(t *testing.T) {
+	assertCanonize := func(t *testing.T, input string, expected string) {
+		got := cmd.CanonizeBuilderImageArg(input)
+		if got != expected {
+			t.Fail()
+		}
+	}
+
+	assertCanonize(t, "docker://docker.io/centos/nodejs-10-centos7", "docker://docker.io/centos/nodejs-10-centos7")
+	assertCanonize(t, "docker.io/centos/nodejs-10-centos7", "docker://docker.io/centos/nodejs-10-centos7")
+}


### PR DESCRIPTION
- [x] Graduate the `--as-dockerfile` flag in s2i build from "EXPERIMENTAL" to a normal flag.
- [x] Update our docs on Github with the new command and syntax.
- [x] Mark the new generate command as "Tech Preview" so that we're consistent with the rest of the OpenShift ecosystem.