### PR TITLE
Add option to set TLS from environment variable

### DIFF
--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -438,6 +438,10 @@ func GetDefaultDockerConfig() *api.DockerConfig {
 		cfg.TLSVerify = true
 	}
 
+	if useTLS := os.Getenv("DOCKER_TLS"); useTLS != "" {
+		cfg.UseTLS = true
+	}
+
 	return cfg
 }
 


### PR DESCRIPTION
Add option to set TLS in default docker config from environment variable DOCKER_TLS, same as docker cli (https://github.com/docker/cli/pull/863)