### PR TITLE
Adjust test-stirunimage.sh to test either s2i binary or its container image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,27 @@
+---
 language: go
-
 go:
   - 1.13.x
-
-install:
-  - make install-travis
-
-script:
-  - GOFLAGS="-mod=vendor" make verify
-  - GOFLAGS="-mod=vendor" make check TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
-
 notifications:
   irc: "chat.freenode.net#openshift-dev"
-
-sudo: false
-
 matrix:
   allow_failures:
-  - go: master
+    - go: master
   fast_finish: true
+services:
+  - docker
+env:
+  global:
+    - S2I_GIT_VERSION=""
+    - S2I_GIT_MAJOR=""
+    - S2I_GIT_MINOR=""
+install:
+  - make install-travis
+script:
+  # running project linting, static tests
+  - GOFLAGS="-mod=vendor" make verify
+  # running unit tests
+  - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
+  # test image
+  - make test-image
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
   - GOFLAGS="-mod=vendor" make verify
   # running unit tests
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
+  # build image from current branch
+  - GOFLAGS="-mod=vendor" make image
   # test image
   - make test-image
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
     - S2I_GIT_VERSION=""
     - S2I_GIT_MAJOR=""
     - S2I_GIT_MINOR=""
+before_install:
+  # add registry.redhat.io as insecure registry
+  - "sudo cat /etc/docker/daemon.json | jq '. + {\"insecure-registries\": [\"registry.redhat.io\"]}' | sudo tee /etc/docker/daemon.json"
+  - "sudo service docker restart"
 install:
   - make install-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ env:
     - S2I_GIT_VERSION=""
     - S2I_GIT_MAJOR=""
     - S2I_GIT_MINOR=""
-before_install:
-  # add registry.redhat.io as insecure registry
-  - "sudo cat /etc/docker/daemon.json | jq '. + {\"insecure-registries\": [\"registry.redhat.io\"]}' | sudo tee /etc/docker/daemon.json"
-  - "sudo service docker restart"
 install:
   - make install-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ script:
   # running unit tests
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
   # build image from current branch
-  - make image && docker images && make test-image
+  - make image
+  - sudo docker images
+  - make test-image

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
   # build image from current branch
   - GOFLAGS="-mod=vendor" make image
+  # list images
+  - docker images
   # test image
   - make test-image
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,5 @@ script:
   # running unit tests
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
   # build image from current branch
-  - GOFLAGS="-mod=vendor" make image
-  # list images
-  - docker images
-  # test image
-  - make test-image
+  - make image && docker images && make test-image
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 install:
   - make install-travis
 script:
+  - docker info
   # running project linting, static tests
   - GOFLAGS="-mod=vendor" make verify
   # running unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ script:
   # running unit tests
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
   # build image from current branch
-  - make image && docker images && sudo make test-image
-
+  - make image && docker images && make test-image

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   # running unit tests
   - GOFLAGS="-mod=vendor" make test TESTFLAGS="-p=4" TESTS="''" # empty quotes are because hack/test-go.sh requires 2 args
   # build image from current branch
-  - make image && docker images && make test-image
+  - make image && docker images && sudo make test-image
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-docker:
 # Example:
 #	make test-image
 test-image:
-	hack/test-stirunimage.sh
+	S2I_TEST_RUNNER=docker hack/test-stirunimage.sh
 .PHONY: test-image
 
 # Remove all build artifacts.

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,13 @@ install-travis:
 check: verify test	
 .PHONY: check
 
+# Build sti image.
+# Example:
+#	make image
+image:
+	hack/build-base-images.sh
+.PHONY: image
+
 # Run unit tests
 # Example:
 #   make test

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,13 @@ test-docker:
 	hack/test-docker.sh $(TESTFLAGS)
 .PHONY: test-docker
 
+# Run tests on the s2i image.
+# Example:
+#	make test-image
+test-image:
+	hack/test-stirunimage.sh
+.PHONY: test-image
+
 # Remove all build artifacts.
 #
 # Example:

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -9,11 +9,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-S2I_ROOT=$(dirname "${BASH_SOURCE}")/..
+S2I_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${S2I_ROOT}/hack/common.sh"
 
+s2i::build::get_version_vars
+s2i::build::save_version_vars "${S2I_ROOT}/sti-version-defs"
+
 # Go to the top of the tree.
-cd "${S2I_ROOT}"
+pushd "${S2I_ROOT}"
 
 # Build the images
-docker build --tag openshift/sti-release "${S2I_ROOT}/images/release"
+docker build --tag "openshift/sti-release:${S2I_GIT_COMMIT}" "${S2I_ROOT}" -f "${S2I_ROOT}/images/release/Dockerfile"
+
+popd

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -o errexit
 set -o nounset

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -122,6 +122,7 @@ trap cleanup EXIT SIGINT
 echo "working dir:  ${WORK_DIR}"
 echo "s2i working dir:  ${S2I_WORK_DIR}"
 echo "s2i runner: ${S2I_TEST_RUNNER}"
+echo "s2i image: ${S2I_TEST_IMAGE:-not specified}"
 
 pushd ${WORK_DIR}
 

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -103,7 +103,7 @@ function _docker_runner() {
     # * The current user and group are set to allow the user to read the produced files from the host.
     #
     docker_args=(run -i --rm -w "${PWD}" -v "${WORK_DIR}:${WORK_DIR}" -v "${PWD}:${PWD}" -v /tmp:/tmp -v /var/run/docker.sock:/var/run/docker.sock -u "$(id -u):$(id -g)" "${S2I_TEST_IMAGE}" "$@")
-    docker "${docker_args[@]}"
+    sudo docker "${docker_args[@]}"
 }
 
 

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -3,6 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o functrace
 
 S2I_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${S2I_ROOT}/hack/common.sh"

--- a/hack/test-stirunimage.sh
+++ b/hack/test-stirunimage.sh
@@ -115,6 +115,7 @@ function _s2i_runner() {
 
 # s2i executes the runner specified by the S2I_TEST_RUNNER environment variable.
 function s2i() {
+    echo "Starting ${S2I_TEST_RUNNER}"
     "_${S2I_TEST_RUNNER}_runner" "$@"
 }
 

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -3,21 +3,50 @@
 #
 # The standard name for this image is openshift/sti-release
 #
-FROM registry.redhat.io/ubi8/ubi
+FROM openshift/origin-release:golang-1.13
 
-ENV VERSION=1.12.5 \
-    GOARM=5 \
+ENV S2I_GIT_VERSION="" \
+    S2I_GIT_MAJOR="" \
+    S2I_GIT_MINOR=""
+
+ENV GOARM=5 \
     GOPATH=/go \
     GOROOT=/usr/local/go \
     S2I_VERSION_FILE=/go/src/github.com/openshift/source-to-image/sti-version-defs
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
-RUN yum install -y gcc zip && \
-    yum clean all && \
-    curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    touch /sti-build-image
-
 WORKDIR /go/src/github.com/openshift/source-to-image
+COPY . .
 
-# Expect a tar with the source of STI (and /sti-version-defs in the root)
-CMD tar mxzf - && hack/build-cross.sh
+ENV GOARCH="amd64"
+
+USER root
+
+RUN make
+
+FROM registry.redhat.io/ubi8/ubi
+
+ENV GOARCH="amd64" \
+    S2I_WORKING_DIR="/var/lib/source-to-image" \
+    S2I_VERSION_FILE=/go/src/github.com/openshift/source-to-image/sti-version-defs
+
+COPY --from=0 /go/src/github.com/openshift/source-to-image/_output/local/bin/linux/${GOARCH}/s2i /usr/local/bin/s2i
+
+RUN mkdir /var/lib/source-to-image \
+    && chmod 0666 /var/lib/source-to-image
+
+# Inform dependency in the PR.
+RUN yum install -y git && \
+    yum clean all && \
+    ; \
+    rm -rfv /var/cache /var/log/dnf* /var/log/yum.*
+
+WORKDIR /var/lib/source-to-image
+
+USER 1001
+
+ENTRYPOINT [ "/usr/local/bin/s2i" ]
+
+VOLUME /var/run/docker.sock
+
+VOLUME /var/lib/source-to-image

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir /var/lib/source-to-image \
 
 # Inform dependency in the PR.
 RUN yum install -y git && \
-    yum clean all && \
+    yum clean all \
     ; \
     rm -rfv /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -24,7 +24,7 @@ USER root
 
 RUN make
 
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV GOARCH="amd64" \
     S2I_WORKING_DIR="/var/lib/source-to-image" \


### PR DESCRIPTION
test-stirunimage.sh script has been changed to exercise both s2i binary and its container image.

The motivation for this change is to make sure both artefacts work as expected.