### PR TITLE
Update of new_labels.md on a bug and corresponding workaround in OpenShift 4.x

### DIFF
--- a/docs/new_labels.md
+++ b/docs/new_labels.md
@@ -25,3 +25,9 @@ Note: If the JSON format is different than shown above, it will cause an error.
 
 ## Creating the File
 The file should be created during the `assemble` step. 
+
+## Notes on OpenShift 4.x
+The feature of updating output image labels as described above is currently not working in OpenShift 4.x at the time of writing this section (04.14.2020). See the error report at https://bugzilla.redhat.com/show_bug.cgi?id=1758305#c20
+
+A workaround is to update the output image labels during building by adding custom labels to the BuildConfig as described in https://docs.openshift.com/container-platform/4.3/builds/managing-build-output.html#builds-output-image-labels_managing-build-output
+


### PR DESCRIPTION
A new section is added to new_labels.md on a bug in OpenShift 4.x. The method of updating output image labels during the s2i build process is not possible currently in OpenShift 4.x and a corresponding workaround is described.