### PR TITLE
Use volume mount in release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .vscode/
 cmd/s2i/debug
 *~
+
+# Version definition file used in release build
+sti-version-defs

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -15,9 +15,10 @@ ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 RUN yum install -y gcc zip && \
     yum clean all && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    touch /sti-build-image
+    touch /sti-build-image && \
+    mkdir -p /go/src/github.com/openshift/source-to-image
 
 WORKDIR /go/src/github.com/openshift/source-to-image
-
-# Expect a tar with the source of STI (and /sti-version-defs in the root)
-CMD tar mxzf - && hack/build-cross.sh
+VOLUME ["/go/src/github.com/openshift/source-to-image"]
+# Expect source to be mounted in
+CMD ["./hack/build-cross.sh"]


### PR DESCRIPTION
- Use bind mount instead of tar stream to add source code to the release
  container.
- Update release Dockerfile to declare volume for the s2i source.
  Command updated to remove tar stream in
- Add sti-version-defs file to .gitignore