### PR TITLE
Strip groups before checking if AssembleUser is Allowed

### DIFF
--- a/pkg/docker/util.go
+++ b/pkg/docker/util.go
@@ -318,7 +318,7 @@ func CheckAllowedUser(d Docker, imageName string, uids user.RangeList, isOnbuild
 		return err
 	}
 	if len(assembleUser) > 0 {
-		if !user.IsUserAllowed(assembleUser, &uids) {
+		if !user.IsUserAllowed(extractUser(assembleUser), &uids) {
 			// Pass in the override, since assembleUser can come from the image label
 			return s2ierr.NewAssembleUserNotAllowedError(imageName, false)
 		}


### PR DESCRIPTION
When checking if the user that we'll use for running the assemble step is in the allowed user range, we strip any potential group part from the value for the user that we extract from the image's configuration before checking if it's in the allowed range, but we haven't been doing that for values configured through the "s2i.assemble-user" label.