### PR TITLE
Add {linux,darwin}/aarch64 to cross-compile platforms.

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -34,6 +34,8 @@ readonly S2I_CROSS_COMPILE_PLATFORMS=(
   linux/386
   linux/ppc64le
   linux/s390x
+  linux/aarch64
+  darwin/aarch64
 )
 readonly S2I_CROSS_COMPILE_TARGETS=(
   cmd/s2i


### PR DESCRIPTION
Fixes https://github.com/openshift/source-to-image/issues/1077.

@adambkaplan ptal.