### PR TITLE
Fix tests after git CVE-2022-39253 fix

### DIFF
--- a/pkg/scm/git/testhelpers.go
+++ b/pkg/scm/git/testhelpers.go
@@ -77,7 +77,7 @@ func CreateLocalGitDirectoryWithSubmodule() (string, error) {
 		return "", err
 	}
 
-	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "submodule", "add", submodule, "submodule")
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "-c", "protocol.file.allow=always", "submodule", "add", submodule, "submodule")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The problem and suggested workaround are "documented" at https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html

This is needed to fix s2i in koschei (iow prevent FTBFS in future builds): https://koschei.fedoraproject.org/package/source-to-image