### PR TITLE
Re-enable cross builds for aarch64/arm64

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -34,8 +34,8 @@ readonly S2I_CROSS_COMPILE_PLATFORMS=(
   linux/386
   linux/ppc64le
   linux/s390x
-  #linux/aarch64
-  #darwin/aarch64
+  linux/arm64
+  darwin/arm64
 )
 readonly S2I_CROSS_COMPILE_TARGETS=(
   cmd/s2i


### PR DESCRIPTION
When running `go tool dist list` aarch64 is no longer listed so we must change it to arm64 which is the same architecture just a different name

Fixes #1103