### PR TITLE
refactor(fs): simplify CopyContents

### DIFF
--- a/pkg/util/fs/fs.go
+++ b/pkg/util/fs/fs.go
@@ -287,12 +287,7 @@ func (h *fs) CopyContents(src, dest string, isIgnored func(path string) bool) (e
 	if err = os.MkdirAll(dest, sourceinfo.Mode()); err != nil {
 		return err
 	}
-	directory, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer directory.Close()
-	objects, err := directory.Readdir(-1)
+	objects, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`

Reference: https://pkg.go.dev/os#ReadDir