### PR TITLE
Generate SHA512SUM for release archives

### DIFF
--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -185,9 +185,9 @@ func TestBasicDelKeepMix(t *testing.T) {
 /*
 Per the docker user guide, with a docker ignore list of:
 
-    LICENSE.*
-    !LICENSE.md
-    *.md
+	LICENSE.*
+	!LICENSE.md
+	*.md
 
 LICENSE.MD will NOT be kept, as *.md overrides !LICENSE.md
 */

--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -23,9 +23,11 @@ func (t *TimeoutError) Error() string {
 // case that the execution time of the function exceeded the provided duration.
 // The provided function is passed the timer in case it wishes to reset it.  If
 // so, the following pattern must be used:
-// if !timer.Stop() {
-//   return &TimeoutError{}
-// }
+//
+//	if !timer.Stop() {
+//	  return &TimeoutError{}
+//	}
+//
 // timer.Reset(timeout)
 func TimeoutAfter(t time.Duration, errorMsg string, f func(*time.Timer) error) error {
 	c := make(chan error, 1)


### PR DESCRIPTION
The `make release` command will now generate a `SHA512-SUMS.txt` file that should be uploaded to github when a release is made.

Also fixed an issue with the arm64 windows release not having a zip extension.