### PR TITLE
BUILD-960: Update Containers to UBI9 go-toolset

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ OUT_DIR = _output
 
 export GOFLAGS
 
+VERSION = latest
+CONTAINER_ENGINE = podman
+
 # Build code.
 #
 # Args:
@@ -23,6 +26,9 @@ export GOFLAGS
 all build:
 	hack/build-go.sh
 .PHONY: all build
+
+build-container:
+	${CONTAINER_ENGINE} build -t localhost/source-to-image/s2i:${VERSION} .
 
 # Verify if code is properly organized.
 #
@@ -97,6 +103,6 @@ clean:
 # Example:
 #   make release
 release: clean
-	hack/build-release.sh
+	S2I_BUILD_CMD="${CONTAINER_ENGINE}" hack/build-release.sh
 	hack/extract-release.sh
 .PHONY: release

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -37,11 +37,11 @@ echo "++ Building release ${S2I_GIT_VERSION}"
 # Perform the build and release in podman or docker.
 if [[ "$(go env GOHOSTOS)" == "darwin" ]]; then
     $buildCmd run --rm -it -e RELEASE_LDFLAGS="-w -s" \
-  -v "${S2I_ROOT}":/go/src/github.com/openshift/source-to-image \
+  -v "${S2I_ROOT}":/opt/app-root/src/source-to-image \
   openshift/sti-release
   else
     $buildCmd run --rm -it -e RELEASE_LDFLAGS="-w -s" \
-  -v "${S2I_ROOT}":/go/src/github.com/openshift/source-to-image:z \
+  -v "${S2I_ROOT}":/opt/app-root/src/source-to-image:z \
   openshift/sti-release
   fi
 

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -3,22 +3,14 @@
 #
 # The standard name for this image is openshift/sti-release
 #
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
 
-ENV VERSION=1.20 \
-    GOARM=5 \
-    GOPATH=/go \
-    GOROOT=/usr/local/go \
-    S2I_VERSION_FILE=/go/src/github.com/openshift/source-to-image/sti-version-defs
-ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+USER root
+ENV S2I_VERSION_FILE=/opt/app-root/src/source-to-image/sti-version-defs
 
-RUN yum install -y git gcc zip && \
-    yum clean all && \
-    curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    touch /sti-build-image && \
-    mkdir -p /go/src/github.com/openshift/source-to-image
+RUN mkdir -p /opt/app-root/src/source-to-image
 
-WORKDIR /go/src/github.com/openshift/source-to-image
-VOLUME ["/go/src/github.com/openshift/source-to-image"]
+WORKDIR /opt/app-root/src/source-to-image
+VOLUME ["/opt/app-root/src/source-to-image"]
 # Expect source to be mounted in
 CMD ["./hack/build-cross.sh"]


### PR DESCRIPTION
- Update Dockerfiles to use the ubi9 go-toolset images. For the releaser image, this avoids downloading the go sdk as part of the relase process.
- Add `build-container` make target for convenience.
- Update ci-operator build root to use rhel-9 golang 1.20 image for OCP 4.15