### PR TITLE
Use UBI8 based base image and builder image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.atom-build.yml
 /.project
 /.vagrant
+/.idea
 cmd/s2i/debug
 *~
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.21.13 AS builder
+FROM registry.redhat.io/ubi8/go-toolset:1.21 AS builder
 
 ENV S2I_GIT_VERSION="" \
     S2I_GIT_MAJOR="" \
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 go build -a -ldflags="-s -w" -o /tmp/s2i ./cmd/s2i
 # Runner Image
 #
 
-FROM registry.redhat.io/ubi9/ubi-minimal:9.4
+FROM registry.redhat.io/ubi8/ubi-minimal:8.10
 
 COPY --from=builder /tmp/s2i /usr/local/bin/s2i
 


### PR DESCRIPTION
Changes:
- Use UIB8 based base imgae
- Use go-toolset from UBI8

Currently comet repo exists for rhel-8 based images, so to onboard to konflux easily we'll go ahead with rehl-8 image now. When comet repo for rhel-9 is configured, we'll switch to rehl-9 based images.