### PR TITLE
BUILD-1165: Updating s2i to golang 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/ubi8/go-toolset:1.21 AS builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22.7-5 AS builder
 
-ENV S2I_GIT_VERSION="1.4.1" \
+ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \
-    S2I_GIT_MINOR="4"
+    S2I_GIT_MINOR="5"
 
 COPY . .
 
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o /tm
 # Runner Image
 #
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.10
+FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1130
 
 COPY --from=builder /tmp/s2i /usr/local/bin/s2i
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/source-to-image
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/containers/image/v5 v5.31.1


### PR DESCRIPTION
Updating the Dockerfile and go.mod to require golang 1.22. Changing the go runtime also requires a bump to the s2i minor version.

Dockerfile has also been updated to use the "patch" version of the UBI base images. This ensures we have reproducible builds, since the "patch" tags from Red Hat are effectively immutable. Konflux should also provide updates to the patch version through Renovate.