### PR TITLE
BUILD-1165: Updating Dockerfile to us golang 1.22 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/ubi8/go-toolset:1.21.13-1.1727869850 AS builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22.7-5 AS builder
 
-ENV S2I_GIT_VERSION="1.4.1" \
+ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \
-    S2I_GIT_MINOR="4"
+    S2I_GIT_MINOR="5"
 
 COPY . .
 


### PR DESCRIPTION
Mirror of https://github.com/openshift/source-to-image/pull/1191
Updating the Dockerfile to require golang 1.22. Golang version was already updated to 1.22.5

Dockerfile has also been updated to use the "patch" version of the UBI base images. This ensures we have reproducible builds, since the "patch" tags from Red Hat are effectively immutable. Konflux should also provide updates to the patch version through Renovate.