### PR TITLE
BUILD-1190: Add FIPS compliance

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-golang-1.21-openshift-4.16
+  tag: rhel-8-golang-1.22-openshift-4.16

--- a/.tekton/source-to-image-pull-request.yaml
+++ b/.tekton/source-to-image-pull-request.yaml
@@ -29,6 +29,18 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
+  - name: prefetch-input
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -82,7 +94,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
@@ -108,9 +120,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/source-to-image-push.yaml
+++ b/.tekton/source-to-image-push.yaml
@@ -26,6 +26,18 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-tools-s2i-tenant/source-to-image:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
+  - name: prefetch-input
+    value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -79,7 +91,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
@@ -105,9 +117,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM registry.redhat.io/ubi8/go-toolset:1.22.7-5 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset@sha256:be796155c0908cd48375bf1f7150036bcd3ad415dfb6cae135f1cf184d61964c AS builder
 
 ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \
     S2I_GIT_MINOR="5"
 
+ENV GOEXPERIMENT=strictfipsruntime
+
 COPY . .
 
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o /tmp/s2i ./cmd/s2i
+RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime exclude_graphdriver_btrfs" -o /tmp/s2i ./cmd/s2i
 
-#
-# Runner Image
-#
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1130
+FROM registry.access.redhat.com/ubi8@sha256:37cdac4ec130a64050d6df4e1f2ef3f53868bea55d11f623d141f139ee342bd8
 
 COPY --from=builder /tmp/s2i /usr/local/bin/s2i
 
@@ -24,7 +23,7 @@ LABEL \
     name="source-to-image/source-to-image" \
     description="Source-to-Image is a builder image" \
     summary="Source-to-Image is a builder image" \
-    version="1.4.1" \
+    version="1.5.0" \
     vendor="Red Hat, Inc." \
     com.redhat.component="source-to-image-container" \
     maintainer="openshift-builds@redhat.com" \
@@ -32,4 +31,4 @@ LABEL \
     io.k8s.display-name="Source-to-Image" \
     io.openshift.tags="source-to-image,s2i" \
     io.openshift.maintainer.product="OpenShift Container Platform" \
-    io.openshift.maintainer.component="Source-to-Image" \
+    io.openshift.maintainer.component="Source-to-Image"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/source-to-image
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/containers/image/v5 v5.31.1


### PR DESCRIPTION
Changes:
- Update Go to 1.22
- Update Dockerfile for FIPS compliance
- Disable btrfs to prevent build error due to missing library btrfs/ioct.h