### PR TITLE
BUILD-1441: Update golang to 1.23

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-golang-1.22-openshift-4.16
+  tag: rhel-9-golang-1.23-openshift-4.19

--- a/.tekton/source-to-image-rhel8-pull-request.yaml
+++ b/.tekton/source-to-image-rhel8-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "master"
+      target_branch == "master" &&
       (
         files.all.exists(x, x.matches('cmd/|pkg/')) ||
         files.all.exists(x, x.matches('go.mod|go.sum|rhel8.Dockerfile')) ||

--- a/.tekton/source-to-image-rhel9-push.yaml
+++ b/.tekton/source-to-image-rhel9-push.yaml
@@ -33,7 +33,7 @@ spec:
     value: rhel9.Dockerfile
   - name: build-source-image
     value: "true"
-  - name: hermatic
+  - name: hermetic
     value: "true"
   - name: build-platforms
     value:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 OUT_DIR = _output
 
 export GOFLAGS
+export S2I_BUILD_TAGS = "exclude_graphdriver_btrfs"
 
 VERSION = latest
 CONTAINER_ENGINE = podman

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/source-to-image
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/containers/image/v5 v5.31.1

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -21,6 +21,7 @@ S2I_OUTPUT_BINPATH="${S2I_OUTPUT}/bin"
 S2I_OUTPUT_PKGDIR="${S2I_OUTPUT}/pkgdir"
 S2I_LOCAL_BINPATH="${S2I_OUTPUT}/go/bin"
 S2I_LOCAL_RELEASEPATH="${S2I_OUTPUT}/releases"
+S2I_BUILD_TAGS="${S2I_BUILD_TAGS:-}"
 RELEASE_LDFLAGS=${RELEASE_LDFLAGS:-""}
 
 
@@ -97,6 +98,7 @@ s2i::build::build_binaries() {
       CGO_ENABLED=0 go install "${goflags[@]:+${goflags[@]}}" \
           -pkgdir "${S2I_OUTPUT_PKGDIR}" \
           -ldflags "${version_ldflags} ${RELEASE_LDFLAGS}" \
+          -tags "${S2I_BUILD_TAGS}" \
           -mod vendor \
           "${binaries[@]}"
       s2i::build::unset_platform_envs "${platform}"

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -3,7 +3,7 @@
 #
 # The standard name for this image is openshift/sti-release
 #
-FROM registry.redhat.io/ubi9/go-toolset:1.22.9 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.23 AS builder
 
 USER root
 ENV S2I_VERSION_FILE=/opt/app-root/src/source-to-image/sti-version-defs

--- a/rhel8.Dockerfile
+++ b/rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 
 ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \

--- a/rhel9.Dockerfile
+++ b/rhel9.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \
     S2I_GIT_MINOR="5"


### PR DESCRIPTION
Changes:
- Update go.mod to 1.23
- Update Dockerfiles and CI