### PR TITLE
chore: use minor version tags for docker images

### DIFF
--- a/rhel8.Dockerfile
+++ b/rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-2.1747789945 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 
 ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \

--- a/rhel9.Dockerfile
+++ b/rhel9.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-2.1747789945 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 ENV S2I_GIT_VERSION="1.5.0" \
     S2I_GIT_MAJOR="1" \
     S2I_GIT_MINOR="5"


### PR DESCRIPTION
- using minor version tags for dockerfile ensures that the images
are built using latest update

Signed-off-by: Avinal Kumar <avinal@redhat.com>
