### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for source-to-image-rhel9

### DIFF
--- a/rhel9.Dockerfile
+++ b/rhel9.Dockerfile
@@ -25,6 +25,7 @@ LABEL \
     version="1.6.0" \
     vendor="Red Hat, Inc." \
     com.redhat.component="source-to-image-container" \
+    cpe="cpe:/a:redhat:source_to_image:1.5::el8" \
     maintainer="openshift-builds@redhat.com" \
     io.k8s.description="Source-to-Image is a builder image" \
     io.k8s.display-name="Source-to-Image" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
