### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/pkg/build/strategies/dockerfile/dockerfile.go
+++ b/pkg/build/strategies/dockerfile/dockerfile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -446,7 +445,7 @@ func getImageScriptsDir(config *api.Config, builder *Dockerfile) (string, map[st
 // scanScripts returns a map of provided s2i scripts
 func scanScripts(name string) map[string]bool {
 	scriptsMap := make(map[string]bool)
-	items, err := ioutil.ReadDir(name)
+	items, err := os.ReadDir(name)
 	if os.IsNotExist(err) {
 		log.Warningf("Unable to access directory %q: %v", name, err)
 	}

--- a/pkg/build/strategies/dockerfile/dockerfile_test.go
+++ b/pkg/build/strategies/dockerfile/dockerfile_test.go
@@ -2,7 +2,6 @@ package dockerfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,7 +160,7 @@ func TestInstallScripts(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			workDir, err := ioutil.TempDir("", "s2i-dockerfile-uploads")
+			workDir, err := os.MkdirTemp("", "s2i-dockerfile-uploads")
 			if err != nil {
 				t.Fatalf("failed to create working dir: %v", err)
 			}
@@ -177,7 +176,7 @@ func TestInstallScripts(t *testing.T) {
 				}
 			}
 
-			tempDir, err := ioutil.TempDir("", "s2i-dockerfile-scripts")
+			tempDir, err := os.MkdirTemp("", "s2i-dockerfile-scripts")
 			if err != nil {
 				t.Fatalf("could not create temp dir: %v", err)
 			}
@@ -221,6 +220,6 @@ func TestInstallScripts(t *testing.T) {
 func createTestScript(dir string, name string) error {
 	script := "echo \"test script\""
 	path := filepath.Join(dir, name)
-	err := ioutil.WriteFile(path, []byte(script), 0700)
+	err := os.WriteFile(path, []byte(script), 0700)
 	return err
 }

--- a/pkg/build/strategies/layered/layered.go
+++ b/pkg/build/strategies/layered/layered.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -73,7 +72,7 @@ func getDestination(config *api.Config) string {
 // checkValidDirWithContents returns true if the parameter provided is a valid,
 // accessible and non-empty directory.
 func checkValidDirWithContents(name string) bool {
-	items, err := ioutil.ReadDir(name)
+	items, err := os.ReadDir(name)
 	if os.IsNotExist(err) {
 		log.Warningf("Unable to access directory %q: %v", name, err)
 	}

--- a/pkg/build/strategies/layered/layered_test.go
+++ b/pkg/build/strategies/layered/layered_test.go
@@ -2,7 +2,6 @@ package layered
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -45,7 +44,7 @@ func newFakeLayeredWithScripts(workDir string) *Layered {
 }
 
 func TestBuildOK(t *testing.T) {
-	workDir, _ := ioutil.TempDir("", "sti")
+	workDir, _ := os.MkdirTemp("", "sti")
 	scriptDir := filepath.Join(workDir, constants.UploadScripts)
 	err := os.MkdirAll(scriptDir, 0700)
 	assemble := filepath.Join(scriptDir, constants.Assemble)
@@ -78,7 +77,7 @@ func TestBuildOK(t *testing.T) {
 }
 
 func TestBuildOKWithImageRef(t *testing.T) {
-	workDir, _ := ioutil.TempDir("", "sti")
+	workDir, _ := os.MkdirTemp("", "sti")
 	scriptDir := filepath.Join(workDir, constants.UploadScripts)
 	err := os.MkdirAll(scriptDir, 0700)
 	assemble := filepath.Join(scriptDir, constants.Assemble)

--- a/pkg/build/strategies/sti/postexecutorstep.go
+++ b/pkg/build/strategies/sti/postexecutorstep.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -242,7 +241,7 @@ type startRuntimeImageAndUploadFilesStep struct {
 func (step *startRuntimeImageAndUploadFilesStep) execute(ctx *postExecutorStepContext) error {
 	log.V(3).Info("Executing step: start runtime image and upload files")
 
-	fd, err := ioutil.TempFile("", "s2i-upload-done")
+	fd, err := os.CreateTemp("", "s2i-upload-done")
 	if err != nil {
 		step.builder.result.BuildInfo.FailureReason = utilstatus.NewFailureReason(
 			utilstatus.ReasonGenericS2IBuildFailed,
@@ -464,7 +463,7 @@ func createCommandForExecutingRunScript(scriptsURL map[string]string, location s
 func downloadAndExtractFileFromContainer(docker dockerpkg.Docker, tar s2itar.Tar, sourcePath, destinationPath, containerID string) (api.FailureReason, error) {
 	log.V(5).Infof("Downloading file %q", sourcePath)
 
-	fd, err := ioutil.TempFile(destinationPath, "s2i-runtime-artifact")
+	fd, err := os.CreateTemp(destinationPath, "s2i-runtime-artifact")
 	if err != nil {
 		res := utilstatus.NewFailureReason(
 			utilstatus.ReasonFSOperationFailed,
@@ -549,7 +548,7 @@ func checkAndGetNewLabels(builder *STI, docker dockerpkg.Docker, tar s2itar.Tar,
 	defer fd.Close()
 
 	// read the file to a string
-	str, err := ioutil.ReadAll(fd)
+	str, err := io.ReadAll(fd)
 	if err != nil {
 		return fmt.Errorf("error reading file '%s' in to a string: %v", filePath, err)
 	}

--- a/pkg/build/strategies/sti/sti.go
+++ b/pkg/build/strategies/sti/sti.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -525,7 +524,7 @@ func (builder *STI) Save(config *api.Config) (err error) {
 	extractFunc := func(string) error {
 		startTime := time.Now()
 		extractErr := builder.tar.ExtractTarStream(artifactTmpDir, outReader)
-		io.Copy(ioutil.Discard, outReader) // must ensure reader from container is drained
+		io.Copy(io.Discard, outReader) // must ensure reader from container is drained
 		builder.result.BuildInfo.Stages = api.RecordStageAndStepInfo(builder.result.BuildInfo.Stages, api.StageRetrieve, api.StepRetrievePreviousArtifacts, startTime, time.Now())
 
 		if extractErr != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -51,7 +51,7 @@ func Save(config *api.Config, cmd *cobra.Command) {
 		log.V(1).Infof("Unable to serialize to %s: %v", DefaultConfigPath, err)
 		return
 	}
-	if err := ioutil.WriteFile(DefaultConfigPath, data, 0644); err != nil {
+	if err := os.WriteFile(DefaultConfigPath, data, 0644); err != nil {
 		log.V(1).Infof("Unable to save %s: %v", DefaultConfigPath, err)
 	}
 	return
@@ -59,9 +59,9 @@ func Save(config *api.Config, cmd *cobra.Command) {
 
 // Restore loads the arguments from disk and prefills the Request
 func Restore(config *api.Config, cmd *cobra.Command) {
-	data, err := ioutil.ReadFile(DefaultConfigPath)
+	data, err := os.ReadFile(DefaultConfigPath)
 	if err != nil {
-		data, err = ioutil.ReadFile(".stifile")
+		data, err = os.ReadFile(".stifile")
 		if err != nil {
 			log.V(1).Infof("Unable to restore %s: %v", DefaultConfigPath, err)
 			return

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -3,8 +3,7 @@ package docker
 import (
 	"bytes"
 	"fmt"
-	"github.com/docker/docker/api/types/image"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +12,7 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	dockerstrslice "github.com/docker/docker/api/types/strslice"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
@@ -131,7 +131,7 @@ func TestCopyToContainer(t *testing.T) {
 		var err error
 		var file *os.File
 		if len(tst.src) > 0 {
-			tempDir, err = ioutil.TempDir("", tst.src)
+			tempDir, err = os.MkdirTemp("", tst.src)
 			defer os.RemoveAll(tempDir)
 			fileName = filepath.Join(tempDir, "bar")
 			if err = os.MkdirAll(filepath.Dir(fileName), 0700); err == nil {
@@ -557,7 +557,7 @@ func TestRunContainer(t *testing.T) {
 			Destination:     tst.paramDestination,
 			Command:         tst.cmd,
 			Env:             []string{"Key1=Value1", "Key2=Value2"},
-			Stdin:           ioutil.NopCloser(os.Stdin),
+			Stdin:           io.NopCloser(os.Stdin),
 		})
 
 		if tst.errResult > 0 {

--- a/pkg/docker/fake_docker.go
+++ b/pkg/docker/fake_docker.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 
 	dockertypes "github.com/docker/docker/api/types"
 
@@ -130,7 +129,7 @@ func (f *FakeDocker) RunContainer(opts RunContainerOptions) error {
 		}
 	}
 	if opts.Stdin != nil {
-		_, err := io.Copy(ioutil.Discard, opts.Stdin)
+		_, err := io.Copy(io.Discard, opts.Stdin)
 		if err != nil {
 			return err
 		}
@@ -210,7 +209,7 @@ func (f *FakeDocker) CheckAndPullImage(name string) (*api.Image, error) {
 func (f *FakeDocker) BuildImage(opts BuildImageOptions) error {
 	f.BuildImageOpts = opts
 	if opts.Stdin != nil {
-		_, err := io.Copy(ioutil.Discard, opts.Stdin)
+		_, err := io.Copy(io.Discard, opts.Stdin)
 		if err != nil {
 			return err
 		}

--- a/pkg/docker/test/client.go
+++ b/pkg/docker/test/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -127,7 +126,7 @@ func (d *FakeDockerClient) CopyToContainer(ctx context.Context, container, path 
 func (d *FakeDockerClient) CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, dockercontainer.PathStat, error) {
 	d.CopyFromContainerID = container
 	d.CopyFromContainerPath = srcPath
-	return ioutil.NopCloser(bytes.NewReader([]byte(""))), dockercontainer.PathStat{}, d.CopyFromContainerErr
+	return io.NopCloser(bytes.NewReader([]byte(""))), dockercontainer.PathStat{}, d.CopyFromContainerErr
 }
 
 // ContainerWait pauses execution until a container exits.
@@ -165,7 +164,7 @@ func (d *FakeDockerClient) ContainerAttach(ctx context.Context, container string
 func (d *FakeDockerClient) ImageBuild(ctx context.Context, buildContext io.Reader, options dockertypes.ImageBuildOptions) (dockertypes.ImageBuildResponse, error) {
 	d.BuildImageOpts = options
 	return dockertypes.ImageBuildResponse{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Body: io.NopCloser(bytes.NewReader([]byte(""))),
 	}, d.BuildImageErr
 }
 
@@ -213,7 +212,7 @@ func (d *FakeDockerClient) ImagePull(ctx context.Context, ref string, options im
 		return nil, d.PullFail
 	}
 
-	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+	return io.NopCloser(bytes.NewReader([]byte{})), nil
 }
 
 // ImageRemove removes an image from the docker host.

--- a/pkg/scm/git/testhelpers.go
+++ b/pkg/scm/git/testhelpers.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func CreateLocalGitDirectory() (string, error) {
 func CreateEmptyLocalGitDirectory() (string, error) {
 	cr := cmd.NewCommandRunner()
 
-	dir, err := ioutil.TempDir(os.TempDir(), "gitdir-s2i-test")
+	dir, err := os.MkdirTemp(os.TempDir(), "gitdir-s2i-test")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/scripts/download_test.go
+++ b/pkg/scripts/download_test.go
@@ -3,7 +3,6 @@ package scripts
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,7 +22,7 @@ type FakeHTTPGet struct {
 
 func (f *FakeHTTPGet) get(url string) (*http.Response, error) {
 	f.url = url
-	f.body = ioutil.NopCloser(strings.NewReader(f.content))
+	f.body = io.NopCloser(strings.NewReader(f.content))
 	return &http.Response{
 		Body:       f.body,
 		StatusCode: f.statusCode,
@@ -81,7 +80,7 @@ type FakeSchemeReader struct {
 }
 
 func (f *FakeSchemeReader) Read(url *url.URL) (io.ReadCloser, error) {
-	return ioutil.NopCloser(strings.NewReader(f.content)), f.err
+	return io.NopCloser(strings.NewReader(f.content)), f.err
 }
 
 func getDownloader() (Downloader, *FakeSchemeReader) {
@@ -98,7 +97,7 @@ func getDownloader() (Downloader, *FakeSchemeReader) {
 func TestDownload(t *testing.T) {
 	dl, fr := getDownloader()
 	fr.content = "test file content"
-	temp, err := ioutil.TempFile("", "testdownload")
+	temp, err := os.CreateTemp("", "testdownload")
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestDownload(t *testing.T) {
 	if len(info.Location) == 0 {
 		t.Errorf("Expected info.Location to be set, got %v", info)
 	}
-	content, _ := ioutil.ReadFile(temp.Name())
+	content, _ := os.ReadFile(temp.Name())
 	if string(content) != fr.content {
 		t.Errorf("Unexpected file content: %s", string(content))
 	}

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -197,7 +196,7 @@ func (t *stiTar) SetExclusionPattern(p *regexp.Regexp) {
 // while excluding files that match the given exclusion pattern
 // It returns the name of the created file
 func (t *stiTar) CreateTarFile(base, dir string) (string, error) {
-	tarFile, err := ioutil.TempFile(base, "tar")
+	tarFile, err := os.CreateTemp(base, "tar")
 	defer tarFile.Close()
 	if err != nil {
 		return "", err

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,7 +46,7 @@ func createTestFiles(baseDir string, dirs []dirDesc, files []fileDesc, links []l
 	}
 	for _, fd := range files {
 		fileName := filepath.Join(baseDir, fd.name)
-		err := ioutil.WriteFile(fileName, []byte(fd.content), fd.mode)
+		err := os.WriteFile(fileName, []byte(fd.content), fd.mode)
 		if err != nil {
 			return err
 		}
@@ -140,7 +139,7 @@ func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDe
 				t.Errorf("File %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
 					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
 			}
-			fileBytes, err := ioutil.ReadAll(tr)
+			fileBytes, err := io.ReadAll(tr)
 			if err != nil {
 				t.Fatalf("Error reading tar %q: %v", filename, err)
 			}
@@ -168,7 +167,7 @@ func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDe
 }
 
 func TestCreateTarStreamIncludeParentDir(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -190,7 +189,7 @@ func TestCreateTarStreamIncludeParentDir(t *testing.T) {
 		t.Fatalf("Cannot create test files: %v", err)
 	}
 	th := New(fs.NewFileSystem())
-	tarFile, err := ioutil.TempFile("", "testtarout")
+	tarFile, err := os.CreateTemp("", "testtarout")
 	if err != nil {
 		t.Fatalf("Unable to create temporary file %v", err)
 	}
@@ -211,7 +210,7 @@ func TestCreateTarStreamIncludeParentDir(t *testing.T) {
 
 func TestCreateTar(t *testing.T) {
 	th := New(fs.NewFileSystem())
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -252,7 +251,7 @@ func TestCreateTar(t *testing.T) {
 func TestCreateTarIncludeDotGit(t *testing.T) {
 	th := New(fs.NewFileSystem())
 	th.SetExclusionPattern(regexp.MustCompile("test3.txt"))
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -292,7 +291,7 @@ func TestCreateTarIncludeDotGit(t *testing.T) {
 func TestCreateTarEmptyRegexp(t *testing.T) {
 	th := New(fs.NewFileSystem())
 	th.SetExclusionPattern(regexp.MustCompile(""))
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp directory for test: %v", err)
@@ -501,7 +500,7 @@ func verifyDirectory(t *testing.T, dir string, dirs []dirDesc, files []fileDesc,
 					relpath, fd.modifiedDate, info.ModTime())
 			}
 			if !info.IsDir() {
-				contentBytes, err := ioutil.ReadFile(path)
+				contentBytes, err := os.ReadFile(path)
 				if err != nil {
 					t.Errorf("Error reading file %q: %v", path, err)
 					return err
@@ -565,7 +564,7 @@ func TestExtractTarStream(t *testing.T) {
 		{"dir01/dir03/tëst3.txt", modificationDate, 0444, "utf-8 header file content", false, ""},
 	}
 	reader, writer := io.Pipe()
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	if err != nil {
 		t.Fatalf("Cannot create temp directory: %v", err)
 	}
@@ -585,7 +584,7 @@ func TestExtractTarStream(t *testing.T) {
 
 func TestExtractTarStreamTimeout(t *testing.T) {
 	reader, writer := io.Pipe()
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	if err != nil {
 		t.Fatalf("Cannot create temp directory: %v", err)
 	}
@@ -602,12 +601,12 @@ func TestExtractTarStreamTimeout(t *testing.T) {
 func TestRoundTripTar(t *testing.T) {
 	tarWriter := New(fs.NewFileSystem())
 	tarReader := New(fs.NewFileSystem())
-	tempDir, err := ioutil.TempDir("", "testtar")
+	tempDir, err := os.MkdirTemp("", "testtar")
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp input directory for test: %v", err)
 	}
-	destDir, err := ioutil.TempDir("", "testExtract")
+	destDir, err := os.MkdirTemp("", "testExtract")
 	defer os.RemoveAll(destDir)
 	if err != nil {
 		t.Fatalf("Cannot create temp extract directory for test: %v", err)

--- a/pkg/test/cmd/cmd.go
+++ b/pkg/test/cmd/cmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/openshift/source-to-image/pkg/util/cmd"
 )
@@ -32,7 +31,7 @@ func (f *FakeCmdRunner) Run(name string, args ...string) error {
 // StartWithStdoutPipe executes a command returning a ReadCloser connected to
 // the command's stdout.
 func (f *FakeCmdRunner) StartWithStdoutPipe(opts cmd.CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
-	return ioutil.NopCloser(&bytes.Buffer{}), f.Err
+	return io.NopCloser(&bytes.Buffer{}), f.Err
 }
 
 // Wait waits for the command to exit.

--- a/pkg/util/callback_test.go
+++ b/pkg/util/callback_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -17,7 +16,7 @@ type FakePost struct {
 
 func (f *FakePost) post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
 	f.url = url
-	f.body, _ = ioutil.ReadAll(body)
+	f.body, _ = io.ReadAll(body)
 	return &f.response, f.err
 }
 

--- a/pkg/util/injection.go
+++ b/pkg/util/injection.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,7 +114,7 @@ func CreateTruncateFilesScript(files []string, scriptName string) (string, error
 		rmScript += fmt.Sprintf("truncate -s0 %q\n", s)
 	}
 
-	f, err := ioutil.TempFile("", "s2i-injection-remove")
+	f, err := os.CreateTemp("", "s2i-injection-remove")
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +122,7 @@ func CreateTruncateFilesScript(files []string, scriptName string) (string, error
 		rmScript += fmt.Sprintf("truncate -s0 %q\n", scriptName)
 	}
 	rmScript += "set +e\n"
-	err = ioutil.WriteFile(f.Name(), []byte(rmScript), 0700)
+	err = os.WriteFile(f.Name(), []byte(rmScript), 0700)
 	return f.Name(), err
 }
 
@@ -131,12 +130,12 @@ func CreateTruncateFilesScript(files []string, scriptName string) (string, error
 // error. The path to the result file is returned. If the provided error is nil, an empty file is
 // created.
 func CreateInjectionResultFile(injectErr error) (string, error) {
-	f, err := ioutil.TempFile("", "s2i-injection-result")
+	f, err := os.CreateTemp("", "s2i-injection-result")
 	if err != nil {
 		return "", err
 	}
 	if injectErr != nil {
-		err = ioutil.WriteFile(f.Name(), []byte(injectErr.Error()), 0700)
+		err = os.WriteFile(f.Name(), []byte(injectErr.Error()), 0700)
 	}
 	return f.Name(), err
 }

--- a/pkg/util/injection_test.go
+++ b/pkg/util/injection_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func TestCreateTruncateFilesScript(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected file %q to exists, got: %v", name, err)
 	}
-	data, err := ioutil.ReadFile(name)
+	data, err := os.ReadFile(name)
 	if err != nil {
 		t.Errorf("Unable to read %q: %v", name, err)
 	}
@@ -43,9 +42,9 @@ func TestCreateTruncateFilesScript(t *testing.T) {
 }
 
 func TestListFilesToTruncate(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "s2i-test-")
-	tmpKeep, err := ioutil.TempDir("", "s2i-test-")
-	tmpNested, err := ioutil.TempDir(tmp, "nested")
+	tmp, err := os.MkdirTemp("", "s2i-test-")
+	tmpKeep, err := os.MkdirTemp("", "s2i-test-")
+	tmpNested, err := os.MkdirTemp(tmp, "nested")
 	if err != nil {
 		t.Errorf("Unable to create temp directory: %v", err)
 	}
@@ -55,9 +54,9 @@ func TestListFilesToTruncate(t *testing.T) {
 		{Source: tmp, Destination: "/foo"},
 		{Source: tmpKeep, Destination: "/this", Keep: true},
 	}
-	f1, _ := ioutil.TempFile(tmp, "foo")
-	f2, _ := ioutil.TempFile(tmpNested, "bar")
-	ioutil.TempFile(tmpKeep, "that")
+	f1, _ := os.CreateTemp(tmp, "foo")
+	f2, _ := os.CreateTemp(tmpNested, "bar")
+	os.CreateTemp(tmpKeep, "that")
 	files, err := ListFilesToTruncate(fs.NewFileSystem(), list)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -101,7 +100,7 @@ func TestCreateInjectionResultFile(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected file %q to exists, got: %v", name, err)
 		}
-		data, err := ioutil.ReadFile(name)
+		data, err := os.ReadFile(name)
 		if err != nil {
 			t.Errorf("Unable to read %q: %v", name, err)
 		}

--- a/test/integration/docker/dockerssl_test.go
+++ b/test/integration/docker/dockerssl_test.go
@@ -6,7 +6,7 @@ package docker
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -36,7 +36,7 @@ func init() {
 		panic(err)
 	}
 
-	ca, err := ioutil.ReadFile("../testdata/ca.crt")
+	ca, err := os.ReadFile("../testdata/ca.crt")
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ func init() {
 	caPool = x509.NewCertPool()
 	caPool.AppendCertsFromPEM(ca)
 
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 type Server struct {

--- a/test/integration/docker/integration_test.go
+++ b/test/integration/docker/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -111,13 +111,13 @@ func getDefaultContext() (context.Context, context.CancelFunc) {
 
 // TestInjectionBuild tests the build where we inject files to assemble script.
 func TestInjectionBuild(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-test-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-test-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tempdir)
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "secret"), []byte("secret"), 0666)
+	err = os.WriteFile(filepath.Join(tempdir, "secret"), []byte("secret"), 0666)
 	if err != nil {
 		t.Errorf("Unable to write content to temporary injection file: %v", err)
 	}
@@ -130,13 +130,13 @@ func TestInjectionBuild(t *testing.T) {
 }
 
 func TestInjectionBuildBadDestination(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-test-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-test-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tempdir)
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "secret"), []byte("secret"), 0666)
+	err = os.WriteFile(filepath.Join(tempdir, "secret"), []byte("secret"), 0666)
 	if err != nil {
 		t.Errorf("Unable to write content to temporary injection file: %v", err)
 	}
@@ -329,7 +329,7 @@ func (i *integrationTest) exerciseCleanBuild(tag string, verifyCallback bool, im
 			// the request body is as expected
 			if callbackHasValidJSON {
 				defer r.Body.Close()
-				body, _ := ioutil.ReadAll(r.Body)
+				body, _ := io.ReadAll(r.Body)
 				type CallbackMessage struct {
 					Success bool
 					Labels  map[string]string

--- a/test/integration/dockerfile/dockerfile_test.go
+++ b/test/integration/dockerfile/dockerfile_test.go
@@ -5,7 +5,6 @@ package dockerfile
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,7 +20,7 @@ import (
 )
 
 func TestDockerfileBuild(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -64,7 +63,7 @@ func TestDockerfileBuild(t *testing.T) {
 }
 
 func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -106,7 +105,7 @@ func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
 }
 
 func TestDockerfileBuildEnv(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -144,7 +143,7 @@ func TestDockerfileBuildEnv(t *testing.T) {
 }
 
 func TestDockerfileBuildLabels(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -183,7 +182,7 @@ func TestDockerfileBuildLabels(t *testing.T) {
 }
 
 func TestDockerfileBuildInjections(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -196,7 +195,7 @@ func TestDockerfileBuildInjections(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		_, err = ioutil.TempFile(injection1, "injectfile-")
+		_, err = os.CreateTemp(injection1, "injectfile-")
 		if err != nil {
 			t.Errorf("Unable to create injection file: %v", err)
 		}
@@ -207,7 +206,7 @@ func TestDockerfileBuildInjections(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create injection dir: %v", err)
 	}
-	_, err = ioutil.TempFile(injection2, "injectfile-2")
+	_, err = os.CreateTemp(injection2, "injectfile-2")
 	if err != nil {
 		t.Errorf("Unable to create injection file: %v", err)
 	}
@@ -263,7 +262,7 @@ func TestDockerfileBuildInjections(t *testing.T) {
 }
 
 func TestDockerfileBuildScriptsURLAssemble(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -303,7 +302,7 @@ func TestDockerfileBuildScriptsURLAssemble(t *testing.T) {
 }
 
 func TestDockerfileBuildScriptsURLRun(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -343,7 +342,7 @@ func TestDockerfileBuildScriptsURLRun(t *testing.T) {
 }
 
 func TestDockerfileBuildScriptsURLNone(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -367,7 +366,7 @@ func TestDockerfileBuildScriptsURLNone(t *testing.T) {
 }
 
 func TestDockerfileBuildSourceScriptsAssemble(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -414,7 +413,7 @@ func TestDockerfileBuildSourceScriptsAssemble(t *testing.T) {
 }
 
 func TestDockerfileBuildSourceScriptsRun(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -465,7 +464,7 @@ func TestDockerfileBuildSourceScriptsRun(t *testing.T) {
 // contains all of the s2i scripts at the given directory, regardless
 // of what is contained in the source.
 func TestDockerfileBuildScriptsURLImage(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -512,7 +511,7 @@ func TestDockerfileBuildScriptsURLImage(t *testing.T) {
 }
 
 func TestDockerfileBuildImageScriptsURLAssemble(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -552,7 +551,7 @@ func TestDockerfileBuildImageScriptsURLAssemble(t *testing.T) {
 }
 
 func TestDockerfileBuildImageScriptsURLRun(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -592,7 +591,7 @@ func TestDockerfileBuildImageScriptsURLRun(t *testing.T) {
 }
 
 func TestDockerfileBuildImageScriptsURLImage(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -639,7 +638,7 @@ func TestDockerfileBuildImageScriptsURLImage(t *testing.T) {
 }
 
 func TestDockerfileBuildScriptsAndImageURL(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -683,19 +682,19 @@ func TestDockerfileBuildScriptsAndImageURL(t *testing.T) {
 // the ScriptsURL and ImageScriptsURL point to a non-image directory.
 // In this event, the ScriptsURL value should take precedence.
 func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
-	scriptsTempDir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	scriptsTempDir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(scriptsTempDir)
 
-	imageTempDir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	imageTempDir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(imageTempDir)
 
-	outputDir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	outputDir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -703,7 +702,7 @@ func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
 
 	scriptsAssemble := filepath.Join(scriptsTempDir, "assemble")
 	assembleData := []byte("#!/bin/bash\necho \"Hello World!\"")
-	err = ioutil.WriteFile(scriptsAssemble, assembleData, 0666)
+	err = os.WriteFile(scriptsAssemble, assembleData, 0666)
 	if err != nil {
 		t.Errorf("Unable to create image assemble file: %v", err)
 	}
@@ -740,7 +739,7 @@ func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
 		filepath.Join(outputDir, "upload/scripts/assemble"),
 	}
 	runDockerfileTest(t, config, expected, nil, expectedFiles, false)
-	dockerfileAssemble, err := ioutil.ReadFile(filepath.Join(outputDir, "upload/scripts/assemble"))
+	dockerfileAssemble, err := os.ReadFile(filepath.Join(outputDir, "upload/scripts/assemble"))
 	if err != nil {
 		t.Errorf("Failed to read uploaded assemble script: %v", err)
 	}
@@ -750,7 +749,7 @@ func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
 }
 
 func TestDockerfileIncrementalBuild(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -791,7 +790,7 @@ func TestDockerfileIncrementalBuild(t *testing.T) {
 }
 
 func TestDockerfileIncrementalSourceSave(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -846,7 +845,7 @@ func TestDockerfileIncrementalSourceSave(t *testing.T) {
 }
 
 func TestDockerfileIncrementalSaveURL(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -894,7 +893,7 @@ func TestDockerfileIncrementalSaveURL(t *testing.T) {
 }
 
 func TestDockerfileIncrementalTag(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -930,7 +929,7 @@ func TestDockerfileIncrementalTag(t *testing.T) {
 }
 
 func TestDockerfileIncrementalAssembleUser(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	tempdir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -966,13 +965,13 @@ func TestDockerfileIncrementalAssembleUser(t *testing.T) {
 }
 
 func TestDockerfileLocalSource(t *testing.T) {
-	localTempDir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	localTempDir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(localTempDir)
 
-	outputDir, err := ioutil.TempDir("", "s2i-dockerfiletest-dir")
+	outputDir, err := os.MkdirTemp("", "s2i-dockerfiletest-dir")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -1003,7 +1002,7 @@ func TestDockerfileLocalSource(t *testing.T) {
 	}
 	for _, fileName := range fileTree {
 		dummyContent := []byte("Hello World!")
-		err = ioutil.WriteFile(filepath.Join(localTempDir, fileName), dummyContent, 0666)
+		err = os.WriteFile(filepath.Join(localTempDir, fileName), dummyContent, 0666)
 		if err != nil {
 			t.Errorf("Unable to create file: %v", err)
 		}
@@ -1022,7 +1021,7 @@ func TestDockerfileLocalSource(t *testing.T) {
 
 	s2iignore := filepath.Join(localTempDir, ".s2iignore")
 	s2iignoreDate := []byte("dummy\n#skip_file\nfoo/bar/another_file\nfoo/baz/foobar")
-	err = ioutil.WriteFile(s2iignore, s2iignoreDate, 0666)
+	err = os.WriteFile(s2iignore, s2iignoreDate, 0666)
 	if err != nil {
 		t.Errorf("Unable to create .s2iignore file: %v", err)
 	}
@@ -1056,7 +1055,7 @@ func runDockerfileTest(t *testing.T, config *api.Config, expected []string, notE
 		t.Fatalf("The build failed when it should have succeeded.")
 	}
 
-	filebytes, err := ioutil.ReadFile(config.AsDockerfile)
+	filebytes, err := os.ReadFile(config.AsDockerfile)
 	if err != nil {
 		t.Fatalf("An error occurred reading the dockerfile: %v", err)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os`/`io`:**

* Replaced `ioutil.ReadDir`, `ioutil.TempDir`, `ioutil.TempFile`, `ioutil.WriteFile`, and `ioutil.ReadFile` with `os.ReadDir`, `os.MkdirTemp`, `os.CreateTemp`, `os.WriteFile`, and `os.ReadFile` respectively throughout the codebase. [[1]](diffhunk://#diff-9b3f60b4cf2cbbb72f0387acb3a984e4288bd7c15677d930b87285227628394fL7) [[2]](diffhunk://#diff-9b3f60b4cf2cbbb72f0387acb3a984e4288bd7c15677d930b87285227628394fL449-R448) [[3]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L5) [[4]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L164-R163) [[5]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L180-R179) [[6]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L224-R223) [[7]](diffhunk://#diff-0aa0b93435cd12409491ac536575954ae400bb847d0fd50e9fa53f0befaaca57L8) [[8]](diffhunk://#diff-0aa0b93435cd12409491ac536575954ae400bb847d0fd50e9fa53f0befaaca57L76-R75) [[9]](diffhunk://#diff-c6c4e3128fba62672e571b77f4553d8ec71fb98ce45542d104150d22f7c968f2L5) [[10]](diffhunk://#diff-c6c4e3128fba62672e571b77f4553d8ec71fb98ce45542d104150d22f7c968f2L48-R47) [[11]](diffhunk://#diff-c6c4e3128fba62672e571b77f4553d8ec71fb98ce45542d104150d22f7c968f2L81-R80) [[12]](diffhunk://#diff-d49b674d5ec4f551dac6c941bfb6c9815cb034fe038235c7429cbe2c1362a4ecL8) [[13]](diffhunk://#diff-d49b674d5ec4f551dac6c941bfb6c9815cb034fe038235c7429cbe2c1362a4ecL245-R244) [[14]](diffhunk://#diff-d49b674d5ec4f551dac6c941bfb6c9815cb034fe038235c7429cbe2c1362a4ecL467-R466) [[15]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L6-R6) [[16]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5L54-R64) [[17]](diffhunk://#diff-8e03c85e513f4729d158895b437d7d202648f7e32440948dce94eb3314bcb72aL6-R6) [[18]](diffhunk://#diff-8e03c85e513f4729d158895b437d7d202648f7e32440948dce94eb3314bcb72aR15) [[19]](diffhunk://#diff-8e03c85e513f4729d158895b437d7d202648f7e32440948dce94eb3314bcb72aL134-R134) [[20]](diffhunk://#diff-bf2aff7e2e645780823977b81ae15df029dd7bf7532a0b9b5b7ffb9483ddac9aL4) [[21]](diffhunk://#diff-bf2aff7e2e645780823977b81ae15df029dd7bf7532a0b9b5b7ffb9483ddac9aL44-R43) [[22]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L6) [[23]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L26-R25) [[24]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L84-R83) [[25]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L101-R100) [[26]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L115-R114) [[27]](diffhunk://#diff-e6baf6d84e25634a899903b52f54cd985b3f1a22b49a6c1c57fa0fd6b74a45cfL7)

* Replaced `ioutil.NopCloser` with `io.NopCloser` where appropriate, and replaced `ioutil.Discard` with `io.Discard`. [[1]](diffhunk://#diff-8e03c85e513f4729d158895b437d7d202648f7e32440948dce94eb3314bcb72aL560-R560) [[2]](diffhunk://#diff-3202afc8a36574847aa917e930d54b98f912ea88f4811c83678132bf327acd73L6) [[3]](diffhunk://#diff-3202afc8a36574847aa917e930d54b98f912ea88f4811c83678132bf327acd73L133-R132) [[4]](diffhunk://#diff-3202afc8a36574847aa917e930d54b98f912ea88f4811c83678132bf327acd73L213-R212) [[5]](diffhunk://#diff-b633371197d45e26131f7015f8f3f386bc7b0a934de61140244fbe05814eee13L9) [[6]](diffhunk://#diff-b633371197d45e26131f7015f8f3f386bc7b0a934de61140244fbe05814eee13L130-R129) [[7]](diffhunk://#diff-b633371197d45e26131f7015f8f3f386bc7b0a934de61140244fbe05814eee13L168-R167) [[8]](diffhunk://#diff-b633371197d45e26131f7015f8f3f386bc7b0a934de61140244fbe05814eee13L216-R215) [[9]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L26-R25) [[10]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L84-R83)

* Updated file reading from `ioutil.ReadAll` to `io.ReadAll`.

**Test code modernization:**

* Updated all test helper functions and test cases to use `os.MkdirTemp`, `os.CreateTemp`, and `os.ReadFile` instead of their `ioutil` counterparts. [[1]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L164-R163) [[2]](diffhunk://#diff-eac5345d61da321f8219cb65463a47f2092e8706bdb90cdc669f5db370fb01c8L180-R179) [[3]](diffhunk://#diff-c6c4e3128fba62672e571b77f4553d8ec71fb98ce45542d104150d22f7c968f2L48-R47) [[4]](diffhunk://#diff-c6c4e3128fba62672e571b77f4553d8ec71fb98ce45542d104150d22f7c968f2L81-R80) [[5]](diffhunk://#diff-8e03c85e513f4729d158895b437d7d202648f7e32440948dce94eb3314bcb72aL134-R134) [[6]](diffhunk://#diff-bf2aff7e2e645780823977b81ae15df029dd7bf7532a0b9b5b7ffb9483ddac9aL44-R43) [[7]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L101-R100) [[8]](diffhunk://#diff-39929777fd03079976dc4c574b45a6054da83bdfe1f4ea6415741d128cf16b62L115-R114)

These changes help ensure the project remains up-to-date with Go's evolving standard library and avoids deprecated functionality.