### PR TITLE
Update release Dockerfiles

### DIFF
--- a/.tekton/source-to-image-unit-test.yaml
+++ b/.tekton/source-to-image-unit-test.yaml
@@ -19,7 +19,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: BASE_IMAGE
       type: string
-      default: registry.access.redhat.com/ubi10/go-toolset:1.25.3
+      default: registry.redhat.io/ubi10/go-toolset:1.25.3
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -3,7 +3,7 @@
 #
 # The standard name for this image is openshift/sti-release
 #
-FROM registry.redhat.io/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.3 AS builder
 
 USER root
 ENV S2I_VERSION_FILE=/opt/app-root/src/source-to-image/sti-version-defs

--- a/rhel8.Dockerfile
+++ b/rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.3 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:1.25.3 AS builder
 
 ENV S2I_GIT_VERSION="1.5.2" \
     S2I_GIT_MAJOR="1" \

--- a/rhel9.Dockerfile
+++ b/rhel9.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.3 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:1.25.3 AS builder
 ENV S2I_GIT_VERSION="1.5.2" \
     S2I_GIT_MAJOR="1" \
     S2I_GIT_MINOR="5"


### PR DESCRIPTION
Changes:
- Konflux Dockerfiles updated to use authenticated UBI images from authenticated registry
- Upstream release Dockerfile updated to use golang builder image 1.25.3