### PR TITLE
OCPTOOLS-908: Update Go version to 1.25.7

### DIFF
--- a/.tekton/source-to-image-unit-test.yaml
+++ b/.tekton/source-to-image-unit-test.yaml
@@ -19,7 +19,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi10/go-toolset:1.25.3
+      default: registry.redhat.io/ubi10/go-toolset@sha256:91fa2bd2d8e4965b9b2c7c5a6de9d7f1155aa717f7c81dd5ccb8c444bf1153ec
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/source-to-image
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -3,7 +3,7 @@
 #
 # The standard name for this image is openshift/sti-release
 #
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.3 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset@sha256:91fa2bd2d8e4965b9b2c7c5a6de9d7f1155aa717f7c81dd5ccb8c444bf1153ec AS builder
 
 USER root
 ENV S2I_VERSION_FILE=/opt/app-root/src/source-to-image/sti-version-defs

--- a/rhel8.Dockerfile
+++ b/rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi10/go-toolset:1.25.3 AS builder
+FROM registry.redhat.io/ubi8/go-toolset@sha256:ff71f60ea4a1b19635828e08322d958346ad3ddc4761772ae43f1ed2e9b799c6 AS builder
 
 ENV S2I_GIT_VERSION="1.5.2" \
     S2I_GIT_MAJOR="1" \

--- a/rhel9.Dockerfile
+++ b/rhel9.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi10/go-toolset:1.25.3 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:b3b98e0b21ddbb979d968ca319b8eebdca121e30d58994072cbf99ce86e5d24e AS builder
 ENV S2I_GIT_VERSION="1.5.2" \
     S2I_GIT_MAJOR="1" \
     S2I_GIT_MINOR="5"


### PR DESCRIPTION
Changes:
- Update Go version from 1.25.3 to 1.25.7 in go.mod
- Update Go builder image to 1.25.7 in Dockerfiles with SHA digests for Konflux
- rhel8.Dockerfile: use UBI8 go-toolset
- rhel9.Dockerfile: use UBI9 go-toolset
- images/release and unit test: use UBI10 go-toolset