### PR TITLE
Update golang to 1.26.2

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-golang-1.25-openshift-4.21
+  tag: rhel-9-golang-1.26-openshift-5.0

--- a/.tekton/source-to-image-unit-test.yaml
+++ b/.tekton/source-to-image-unit-test.yaml
@@ -19,7 +19,7 @@ spec:
     - description: The Go base image used to run the unit tests
       name: BASE_IMAGE
       type: string
-      default: registry.redhat.io/ubi10/go-toolset@sha256:91fa2bd2d8e4965b9b2c7c5a6de9d7f1155aa717f7c81dd5ccb8c444bf1153ec
+      default: registry.access.redhat.com/ubi10/go-toolset@sha256:2a25b4be2dcc671b854a31c5b0269b9de0574a7f24f64dc1d6bf1c472ed18049
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/source-to-image
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/pkg/scm/git/url_test.go
+++ b/pkg/scm/git/url_test.go
@@ -94,11 +94,11 @@ func TestParse(t *testing.T) {
 			},
 		},
 		parseTest{
-			rawurl: "http://::ffff:1.2.3.4:443",
+			rawurl: "http://1.2.3.4:443",
 			expectedGitURL: &URL{
 				URL: url.URL{
 					Scheme: "http",
-					Host:   "::ffff:1.2.3.4:443",
+					Host:   "1.2.3.4:443",
 				},
 				Type: URLTypeURL,
 			},

--- a/rhel8.Dockerfile
+++ b/rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/go-toolset@sha256:140a6cda36debb1d29ca7d5875a886ced762fbbc1a0928924f60266464d19abe AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:a82d974dae02330d0669fb0a5ced2ae498bd1bd708359d61493b9fb0dc0748eb AS builder
 
 ENV S2I_GIT_VERSION="1.6.0" \
     S2I_GIT_MAJOR="1" \


### PR DESCRIPTION
Mitigates [CVE-2026-32282](https://www.cve.org/CVERecord?id=CVE-2026-32282)